### PR TITLE
Add npm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # SDK for Saleor Apps
 
 SDK for building great Saleor Apps.
+
+## Installing
+
+```bash
+npm i @saleor/app-sdk
+```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 SDK for building great Saleor Apps.
 
+<div>
+
+  [![npm version badge](https://img.shields.io/npm/v/@saleor/app-sdk)](https://www.npmjs.com/package/@saleor/app-sdk)
+  [![npm downloads count](https://img.shields.io/npm/dt/@saleor/app-sdk)](https://www.npmjs.com/package/@saleor/app-sdk)
+
+</div>
+
 ## Installing
 
 ```bash


### PR DESCRIPTION
I want to merge this because it adds a link to `npm` with a version badge and installation instructions in README.