### PR TITLE
Fix custom webhooks path not working in development

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,16 @@ const capitalize = (value: string) =>
 
 const dropFileExtension = (filename: string) => path.parse(filename).name;
 
-export const inferWebhooks = async (baseURL: string, webhooksPath: string, generatedGraphQL: any) => {
+export const inferWebhooks = async (
+  baseURL: string,
+  webhooksPath: string,
+  generatedGraphQL: any
+) => {
   let entries;
   if (process.env.NODE_ENV === "production") {
-    entries = await fg(["*.js"], { cwd: webhooksPath });
+    entries = await fg(["*.js"], { cwd: `${__dirname}/${webhooksPath}` });
   } else {
-    entries = await fg(["*.ts"], { cwd: `pages/api/webhooks` });
+    entries = await fg(["*.ts"], { cwd: webhooksPath });
   }
 
   return entries.map(dropFileExtension).map((name: string) => {


### PR DESCRIPTION
I want to merge this because it allows using custom paths for webhooks. Currently in development only the `/pages/api/webhooks` path is used, which makes it impossible to use other path.