### PR TITLE
Fix Webhook signature validation when JWS is malformed

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -95,12 +95,12 @@ export const withWebhookSignatureVerified = (
         signature,
       };
 
-      const jwksKey = await jose.createRemoteJWKSet(
+      const jwks = jose.createRemoteJWKSet(
         new URL(jwksUrl(saleorDomain))
-      )(jose.decodeProtectedHeader(payloadSignature), jws);
+      ) as jose.FlattenedVerifyGetKey;
 
       try {
-        await jose.flattenedVerify(jws, jwksKey);
+        await jose.flattenedVerify(jws, jwks);
       } catch {
         return Response.BadRequest({
           success: false,


### PR DESCRIPTION
I want to merge this because it fixes an 500 Internal Server Error when JWS from request is malformed.

We can simply pass JWKS object into jose's `flattenedVerify` function

