### PR TITLE
Add types for event validation middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,7 +31,7 @@ export const withSaleorDomainPresent: Middleware =
   };
 
 export const withSaleorEventMatch =
-  (expectedEvent: string): Middleware =>
+  <E extends string>(expectedEvent: `${Lowercase<E>}`): Middleware =>
   (handler) =>
   async (request) => {
     const receivedEvent = request.headers[SALEOR_EVENT_HEADER];


### PR DESCRIPTION
I want to merge this, because it allows to use stricter types for accepted `expectedEvent` type in `withSaleorEventMatch` middleware
