### PR TITLE
Drop unused package `watchlist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "tsm": "^2.2.1",
     "tsup": "^6.2.0",
     "typescript": "^4.7.4",
-    "vitest": "^0.21.0",
-    "watchlist": "^0.3.1"
+    "vitest": "^0.21.0"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --cache --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,6 @@ specifiers:
   tsup: ^6.2.0
   typescript: ^4.7.4
   vitest: ^0.21.0
-  watchlist: ^0.3.1
 
 dependencies:
   fast-glob: 3.2.11
@@ -52,7 +51,6 @@ devDependencies:
   tsup: 6.2.0_typescript@4.7.4
   typescript: 4.7.4
   vitest: 0.21.0
-  watchlist: 0.3.1
 
 packages:
 
@@ -1770,11 +1768,6 @@ packages:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
     dev: true
 
-  /mri/1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-    dev: true
-
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: true
@@ -2499,14 +2492,6 @@ packages:
       - stylus
       - supports-color
       - terser
-    dev: true
-
-  /watchlist/0.3.1:
-    resolution: {integrity: sha512-m5r4bzxJ9eg07TT/O0Q49imFPD45ZTuQ3kaHwSpUJj1QwVd3pzit4UYOmySdmAP5Egkz6mB6hcAPuPfhIbNo0g==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      mri: 1.2.0
     dev: true
 
   /webidl-conversions/4.0.2:


### PR DESCRIPTION
Don't think we require this package anymore - I was able to build and run watch mode without it.