### PR TITLE
Fix manifest type to use `asyncEvents` and `syncEvents`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,8 @@ export interface AppExtension {
 
 export interface AppWebhook {
   name: string;
-  events?: WebhookEvent[];
+  asyncEvents?: WebhookEvent[];
+  syncEvents?: WebhookEvent[];
   query: string;
   targetUrl: string;
   isActive?: boolean;


### PR DESCRIPTION
This PR fixes manifest types to use `asyncEvents` and `syncEvents` instead of `events` proerty. See https://github.com/saleor/saleor-docs/pull/542
