### PR TITLE
feat: add getLayout to return type of withAuthorization

### DIFF
--- a/src/app-bridge/with-authorization.tsx
+++ b/src/app-bridge/with-authorization.tsx
@@ -27,6 +27,10 @@ const defaultProps: Props = {
   unmounted: <p>Loading</p>,
 };
 
+type WithAuthorizationHOC<P> = React.FunctionComponent<P> & {
+  getLayout?: (page: React.ReactElement) => React.ReactNode;
+};
+
 /**
  * Most likely, views from your app will be only accessibly inside Dashboard iframe.
  * This HOC can be used to handle all checks, with default messages included.
@@ -38,7 +42,7 @@ export const withAuthorization =
   (props: Props = defaultProps) =>
   <BaseProps extends React.ComponentProps<NextPage>>(
     BaseComponent: React.FunctionComponent<BaseProps>
-  ) => {
+  ): WithAuthorizationHOC<BaseProps> => {
     const { dashboardTokenInvalid, noDashboardToken, notIframe, unmounted } = {
       ...defaultProps,
       ...props,
@@ -67,5 +71,5 @@ export const withAuthorization =
       return <BaseComponent {...innerProps} />;
     }
 
-    return AuthorizedPage;
+    return AuthorizedPage as WithAuthorizationHOC<BaseProps>;
   };


### PR DESCRIPTION
# What was done?
I've added `getLayout` to the return type of `withAuthorization`. Why? Because it turns out you need to apply `getLayout` after you wrap your component with `withAuthorization`. In the current situation TypeScript does not see `getLayout` on a wrapped component.

One example of such an error is [saleor-app-template](https://github.com/saleor/saleor-app-template/blob/main/pages/configuration.tsx#L133) - it turns out that the `Configuration` page will not have layout applied.

After a change in this PR following code will now work properly:

```tsx
function Component() {
  return <div>Component here</div>;
}

const authorizedComponent = withAuthorization()(Component);

authorizedComponent.getLayout = () => (
  <div>
    <Component />
  </div>
);
```
