### PR TITLE
Remove index export

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
       "types": "./saleor-app.d.ts",
       "import": "./saleor-app.mjs",
       "require": "./saleor-app.js"
+    },
+    "./infer-webhooks": {
+      "types": "./infer-webhooks.d.ts",
+      "import": "./infer-webhooks.mjs",
+      "require": "./infer-webhooks.js"
     }
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -115,11 +115,6 @@
       "types": "./handlers/next/index.d.ts",
       "import": "./handlers/next/index.mjs",
       "require": "./handlers/next/index.js"
-    },
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./index.mjs",
-      "require": "./index.js"
     }
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,11 @@
       "types": "./handlers/next/index.d.ts",
       "import": "./handlers/next/index.mjs",
       "require": "./handlers/next/index.js"
+    },
+    "./saleor-app": {
+      "types": "./saleor-app.d.ts",
+      "import": "./saleor-app.mjs",
+      "require": "./saleor-app.js"
     }
   },
   "publishConfig": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,11 +2,12 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: [
-    /**
-     * TODO Introduce breaking change and remove exporting from paths, merge everything to index
-     */
-    "src/*",
-    "src/index.ts",
+    "src/const.ts",
+    "src/types.ts",
+    "src/urls.ts",
+    "src/headers.ts",
+    "src/saleor-app.ts",
+    "src/infer-webhooks.ts",
     "src/APL/index.ts",
     "src/app-bridge/index.ts",
     "src/handlers/next/index.ts",


### PR DESCRIPTION
SDK contains many packages, including node & browser only. Current index import doesn't even work for browser, because it imports node-only code and it breaks.

Hence lets remove it and use tree-shakable imports from specific entry point.

Maybe related for next iteration: #92 

Before merging, lets check if apps work, otherwise fix imports first