### PR TITLE
Remove variables from the env if are already existing in the upstash APL tests

### DIFF
--- a/src/APL/upstash-apl.test.ts
+++ b/src/APL/upstash-apl.test.ts
@@ -122,6 +122,10 @@ describe("APL", () => {
 
     describe("isReady", () => {
       it("Returns error with message mentioning missing configuration variables", async () => {
+        // Delete upstash variables if are already present in the env
+        delete process.env[UpstashAPLVariables.UPSTASH_TOKEN];
+        delete process.env[UpstashAPLVariables.UPSTASH_URL];
+
         const apl = new UpstashAPL();
 
         const result = await apl.isReady();


### PR DESCRIPTION
Existing env variables in my environment caused failing tests.