### PR TITLE
`subscriptionQueryAst` or `query` argument has to be specified for the event subscriptions

### DIFF
--- a/src/handlers/next/process-async-saleor-webhook.ts
+++ b/src/handlers/next/process-async-saleor-webhook.ts
@@ -21,7 +21,8 @@ export type SaleorWebhookError =
   | "NOT_REGISTERED"
   | "SIGNATURE_VERIFICATION_FAILED"
   | "WRONG_METHOD"
-  | "CANT_BE_PARSED";
+  | "CANT_BE_PARSED"
+  | "CONFIGURATION_ERROR";
 
 export class WebhookError extends Error {
   errorType: SaleorWebhookError = "OTHER";
@@ -116,7 +117,7 @@ export const processAsyncSaleorWebhook: ProcessAsyncSaleorWebhook = async <T>({
     parsedBody = JSON.parse(rawBody);
   } catch {
     debug("Request body cannot be parsed");
-    throw new WebhookError("Request body cant be parsed", "CANT_BE_PARSED");
+    throw new WebhookError("Request body can't be parsed", "CANT_BE_PARSED");
   }
 
   // Check if domain is installed in the app

--- a/src/handlers/next/saleor-async-webhook.test.ts
+++ b/src/handlers/next/saleor-async-webhook.test.ts
@@ -1,7 +1,9 @@
+import { ASTNode } from "graphql";
 import { createMocks } from "node-mocks-http";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { APL } from "../../APL";
+import { processAsyncSaleorWebhook } from "./process-async-saleor-webhook";
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "./saleor-async-webhook";
 
 const webhookPath = "api/webhooks/product-updated";
@@ -23,10 +25,40 @@ describe("SaleorAsyncWebhook", () => {
     isConfigured: vi.fn(),
   };
 
-  const saleorAsyncWebhook = new SaleorAsyncWebhook({
+  afterEach(async () => {
+    vi.restoreAllMocks();
+  });
+
+  const validAsyncWebhookConfiguration = {
     apl: mockAPL,
     asyncEvent: "PRODUCT_UPDATED",
     webhookPath,
+    query: "subscription { event { ... on ProductUpdated { product { id }}}}",
+  };
+
+  const saleorAsyncWebhook = new SaleorAsyncWebhook(validAsyncWebhookConfiguration);
+
+  it("throw CONFIGURATION_ERROR if query and subscriptionQueryAst are both absent", async () => {
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new SaleorAsyncWebhook({
+        ...validAsyncWebhookConfiguration,
+        // @ts-ignore: We make type error for test purpose
+        query: undefined,
+        subscriptionQueryAst: undefined,
+      });
+    }).toThrowError();
+  });
+
+  it("constructor passes if subscriptionQueryAst is provided", async () => {
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new SaleorAsyncWebhook({
+        ...validAsyncWebhookConfiguration,
+        query: undefined,
+        subscriptionQueryAst: {} as ASTNode,
+      });
+    }).not.toThrowError();
   });
 
   it("targetUrl should return full path to the webhook route based on given baseUrl", async () => {
@@ -39,18 +71,19 @@ describe("SaleorAsyncWebhook", () => {
       isActive: true,
       name: "PRODUCT_UPDATED webhook",
       targetUrl: "http://example.com/api/webhooks/product-updated",
+      query: "subscription { event { ... on ProductUpdated { product { id }}}}",
     });
   });
 
   it("Test createHandler which return success", async () => {
     // prepare mocked context returned by mocked process function
-    vi.mock("./process-async-saleor-webhook", () => ({
-      processAsyncSaleorWebhook: vi.fn().mockResolvedValue({
-        baseUrl: "example.com",
-        event: "product_updated",
-        payload: { data: "test_payload" },
-        authData: { domain: "example.com", token: "token" },
-      }),
+    vi.mock("./process-async-saleor-webhook");
+
+    vi.mocked(processAsyncSaleorWebhook).mockImplementationOnce(async () => ({
+      baseUrl: "example.com",
+      event: "product_updated",
+      payload: { data: "test_payload" },
+      authData: { domain: "example.com", token: "token" },
     }));
 
     // Test handler - will throw error if mocked context is not passed to it


### PR DESCRIPTION
Event subscription in the manifest require query provided (unlike webhookCreate mutation)