### PR TITLE
Add saleorApiUrl state param to AppBridge

### DIFF
--- a/docs/app-bridge.md
+++ b/docs/app-bridge.md
@@ -35,13 +35,13 @@ type AppBridgeState = {
   token?: string;
   id: string;
   ready: boolean;
-  /**
-   * @deprecated - use saleorApiUrl instead
-   */
   domain: string;
   path: string;
   theme: ThemeType;
   locale: LocaleCode; // See src/locales.ts
+  /**
+   * Full URL including protocol and path where graphql is available
+   */
   saleorApiUrl: string;
 };
 ```

--- a/docs/app-bridge.md
+++ b/docs/app-bridge.md
@@ -17,6 +17,8 @@ Options object is following:
 ```
 type AppBridgeOptions = {
   targetDomain?: string;
+  saleorApiUrl?: string;
+  initialLocale?: LocaleCode;
 };
 ```
 
@@ -33,9 +35,14 @@ type AppBridgeState = {
   token?: string;
   id: string;
   ready: boolean;
+  /**
+   * @deprecated - use saleorApiUrl instead
+   */
   domain: string;
   path: string;
   theme: ThemeType;
+  locale: LocaleCode; // See src/locales.ts
+  saleorApiUrl: string;
 };
 ```
 

--- a/src/app-bridge/app-bridge-state.test.ts
+++ b/src/app-bridge/app-bridge-state.test.ts
@@ -13,6 +13,7 @@ describe("app-bridge-state.ts", () => {
       path: "/",
       theme: "light",
       locale: "en",
+      saleorApiUrl: "",
     });
   });
 
@@ -20,7 +21,8 @@ describe("app-bridge-state.ts", () => {
     const instance = new AppBridgeStateContainer();
 
     const newState: Partial<AppBridgeState> = {
-      domain: "https://my-saleor-instance.cloud",
+      domain: "my-saleor-instance.cloud",
+      saleorApiUrl: "https://my-saleor-instance.cloud/graphql/",
       id: "foo-bar",
       path: "/",
       theme: "light",

--- a/src/app-bridge/app-bridge-state.ts
+++ b/src/app-bridge/app-bridge-state.ts
@@ -9,6 +9,7 @@ export type AppBridgeState = {
   path: string;
   theme: ThemeType;
   locale: LocaleCode;
+  saleorApiUrl: string;
 };
 
 type Options = {
@@ -19,6 +20,7 @@ export class AppBridgeStateContainer {
   private state: AppBridgeState = {
     id: "",
     domain: "",
+    saleorApiUrl: "",
     ready: false,
     path: "/",
     theme: "light",

--- a/src/app-bridge/app-bridge.ts
+++ b/src/app-bridge/app-bridge.ts
@@ -129,9 +129,17 @@ export class AppBridge {
       console.warn("document.referrer is empty");
     }
 
+    if (!this.combinedOptions.saleorApiUrl) {
+      debug("?saleorApiUrl was not found in iframe url");
+    }
+
     if (!this.combinedOptions.targetDomain) {
+      debug("?domain was not found in iframe url");
+    }
+
+    if (!(this.combinedOptions.saleorApiUrl && this.combinedOptions.targetDomain)) {
       console.error(
-        "No domain set, ensure ?domain param in iframe exist or provide in AppBridge constructor"
+        "domain and saleorApiUrl params were not found in iframe url. Ensure at least one of them is present"
       );
     }
 

--- a/src/app-bridge/app-iframe-params.ts
+++ b/src/app-bridge/app-iframe-params.ts
@@ -4,9 +4,6 @@
 export const AppIframeParams = {
   APP_ID: "id",
   THEME: "theme",
-  /**
-   * @deprecated use SALEOR_API_URL
-   */
   DOMAIN: "domain",
   SALEOR_API_URL: "saleorApiUrl",
   LOCALE: "locale",

--- a/src/app-bridge/app-iframe-params.ts
+++ b/src/app-bridge/app-iframe-params.ts
@@ -1,0 +1,13 @@
+/**
+ * Contains keys of SearchParams added to iframe src
+ */
+export const AppIframeParams = {
+  APP_ID: "id",
+  THEME: "theme",
+  /**
+   * @deprecated use SALEOR_API_URL
+   */
+  DOMAIN: "domain",
+  SALEOR_API_URL: "saleorApiUrl",
+  LOCALE: "locale",
+};

--- a/src/app-bridge/index.ts
+++ b/src/app-bridge/index.ts
@@ -4,6 +4,7 @@ export { AppBridge };
 
 export * from "./actions";
 export * from "./app-bridge-provider";
+export * from "./app-iframe-params";
 export * from "./events";
 export * from "./types";
 export * from "./use-dashboard-token";

--- a/src/const.ts
+++ b/src/const.ts
@@ -2,5 +2,6 @@ export const SALEOR_DOMAIN_HEADER = "saleor-domain";
 export const SALEOR_EVENT_HEADER = "saleor-event";
 export const SALEOR_SIGNATURE_HEADER = "saleor-signature";
 export const SALEOR_AUTHORIZATION_BEARER_HEADER = "authorization-bearer";
+export const SALEOR_API_URL_HEADER = "saleor-api-url";
 
 export * from "./locales";

--- a/src/handlers/next/process-async-saleor-webhook.test.ts
+++ b/src/handlers/next/process-async-saleor-webhook.test.ts
@@ -13,6 +13,11 @@ vi.mock("./../../verify-signature", () => ({
       throw new Error("Wrong signature");
     }
   }),
+  verifySignatureFromApiUrl: vi.fn((domain, signature) => {
+    if (signature !== "mocked_signature") {
+      throw new Error("Wrong signature");
+    }
+  }),
 }));
 
 vi.mock("raw-body", () => ({
@@ -43,6 +48,7 @@ describe("processAsyncSaleorWebhook", () => {
         host: "some-saleor-host.cloud",
         "x-forwarded-proto": "https",
         "saleor-domain": "example.com",
+        "saleor-api-url": "https://example.com/graphql/",
         "saleor-event": "product_updated",
         "saleor-signature": "mocked_signature",
         "content-length": "0", // is ignored by mocked raw-body

--- a/src/handlers/next/saleor-async-webhook.ts
+++ b/src/handlers/next/saleor-async-webhook.ts
@@ -127,9 +127,6 @@ export class SaleorAsyncWebhook<TPayload = unknown> {
   /**
    * Wraps provided function, to ensure incoming request comes from registered Saleor instance.
    * Also provides additional `context` object containing typed payload and request properties.
-   *
-   * @param handlerFn NextApiHandler function which takes additional `context` argument
-   * @returns NextApiHandler
    */
   createHandler(handlerFn: NextWebhookApiHandler<TPayload>): NextApiHandler {
     return async (req, res) => {

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,4 +1,5 @@
 import {
+  SALEOR_API_URL_HEADER,
   SALEOR_AUTHORIZATION_BEARER_HEADER,
   SALEOR_DOMAIN_HEADER,
   SALEOR_EVENT_HEADER,
@@ -8,13 +9,12 @@ import {
 const toStringOrUndefined = (value: string | string[] | undefined) =>
   value ? value.toString() : undefined;
 
-export const getSaleorHeaders = (headers: {
-  [name: string]: string | string[] | undefined;
-}): Record<string, string | undefined> => ({
+export const getSaleorHeaders = (headers: { [name: string]: string | string[] | undefined }) => ({
   domain: toStringOrUndefined(headers[SALEOR_DOMAIN_HEADER]),
   authorizationBearer: toStringOrUndefined(headers[SALEOR_AUTHORIZATION_BEARER_HEADER]),
   signature: toStringOrUndefined(headers[SALEOR_SIGNATURE_HEADER]),
   event: toStringOrUndefined(headers[SALEOR_EVENT_HEADER]),
+  saleorApiUrl: toStringOrUndefined(headers[SALEOR_API_URL_HEADER]),
 });
 
 export const getBaseUrl = (headers: { [name: string]: string | string[] | undefined }): string => {

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -4,9 +4,18 @@
 const resolveUrlProtocol = (saleorDomain: string): string =>
   saleorDomain === "localhost:8000" ? "http" : "https";
 
+/**
+ * @deprecated use getJwksUrlFromSaleorApiUrl
+ */
 export const getJwksUrl = (saleorDomain: string): string =>
   `${resolveUrlProtocol(saleorDomain)}://${saleorDomain}/.well-known/jwks.json`;
 
+export const getJwksUrlFromSaleorApiUrl = (saleorApiUrl: string): string =>
+  `${new URL(saleorApiUrl).origin}/.well-known/jwks.json`;
+
+/**
+ * @deprecated Use saleor-api-url header
+ */
 export const getGraphQLUrl = (saleorDomain: string): string =>
   `${resolveUrlProtocol(saleorDomain)}://${saleorDomain}/graphql/`;
 

--- a/src/verify-signature.ts
+++ b/src/verify-signature.ts
@@ -1,13 +1,13 @@
 import * as jose from "jose";
 
 import { createDebug } from "./debug";
-import { getJwksUrl } from "./urls";
+import { getJwksUrl, getJwksUrlFromSaleorApiUrl } from "./urls";
 
 const debug = createDebug("verify-signature");
 
 /**
- * Verify payload signature with public key of given `domain`
- * https://docs.saleor.io/docs/3.x/developer/extending/apps/asynchronous-webhooks#payload-signature
+ * @deprecated
+ * use verifySignatureFromApiUrl
  */
 export const verifySignature = async (domain: string, signature: string, rawBody: string) => {
   const [header, , jwsSignature] = signature.split(".");
@@ -19,6 +19,37 @@ export const verifySignature = async (domain: string, signature: string, rawBody
 
   const remoteJwks = jose.createRemoteJWKSet(
     new URL(getJwksUrl(domain))
+  ) as jose.FlattenedVerifyGetKey;
+
+  debug("Created remote JWKS");
+
+  try {
+    await jose.flattenedVerify(jws, remoteJwks);
+    debug("JWKS verified");
+  } catch {
+    debug("JWKS verification failed");
+    throw new Error("JWKS verification failed");
+  }
+};
+
+/**
+ * Verify payload signature with public key of given `domain`
+ * https://docs.saleor.io/docs/3.x/developer/extending/apps/asynchronous-webhooks#payload-signature
+ */
+export const verifySignatureFromApiUrl = async (
+  apiUrl: string,
+  signature: string,
+  rawBody: string
+) => {
+  const [header, , jwsSignature] = signature.split(".");
+  const jws: jose.FlattenedJWSInput = {
+    protected: header,
+    payload: rawBody,
+    signature: jwsSignature,
+  };
+
+  const remoteJwks = jose.createRemoteJWKSet(
+    new URL(getJwksUrlFromSaleorApiUrl(apiUrl))
   ) as jose.FlattenedVerifyGetKey;
 
   debug("Created remote JWKS");


### PR DESCRIPTION
This PR exposes access to new saleor-api-url header which is predictable URL for graphql

Ref #94 