### PR TITLE
Add action that informs Dashboard that AppBridge is ready

### DIFF
--- a/docs/app-bridge.md
+++ b/docs/app-bridge.md
@@ -19,6 +19,7 @@ type AppBridgeOptions = {
   targetDomain?: string;
   saleorApiUrl?: string;
   initialLocale?: LocaleCode;
+  autoNotifyReady?: boolean;
 };
 ```
 
@@ -153,13 +154,13 @@ handleRedirect();
 
 ### Available actions
 
-| Action          | Arguments                                                        | Description                                            |
-| :-------------- | :--------------------------------------------------------------- | :----------------------------------------------------- |
-| `Redirect`      | `to` (string) - relative (inside Dashboard) or absolute URL path |                                                        |
-|                 | `newContext` (boolean) - should open in a new browsing context   |                                                        |
-| `Notification`  | `status` (`info` / `success` / `warning` / `error` / undefined)  |                                                        |
-|                 | `title` (string / undefined) - title of the notification         |                                                        |
-|                 | `text` (string / undefined) - content of the notification        |                                                        |
-|                 | `apiMessage` (string / undefined) - error log from api           |                                                        |
-| `NotifyReady`   |                                                                  | Automatically inform Dashboard that AppBridge is ready |
-| `UpdateRouting` | `newRoute` - current path of App to be set in URL                |                                                        |
+| Action          | Arguments                                                        | Description                              |
+| :-------------- | :--------------------------------------------------------------- | :--------------------------------------- |
+| `Redirect`      | `to` (string) - relative (inside Dashboard) or absolute URL path |                                          |
+|                 | `newContext` (boolean) - should open in a new browsing context   |                                          |
+| `Notification`  | `status` (`info` / `success` / `warning` / `error` / undefined)  |                                          |
+|                 | `title` (string / undefined) - title of the notification         |                                          |
+|                 | `text` (string / undefined) - content of the notification        |                                          |
+|                 | `apiMessage` (string / undefined) - error log from api           |                                          |
+| `NotifyReady`   |                                                                  | Inform Dashboard that AppBridge is ready |
+| `UpdateRouting` | `newRoute` - current path of App to be set in URL                |                                          |

--- a/docs/app-bridge.md
+++ b/docs/app-bridge.md
@@ -153,11 +153,13 @@ handleRedirect();
 
 ### Available actions
 
-| Action         | Arguments                                                        | Description |
-| :------------- | :--------------------------------------------------------------- | :---------- |
-| `Redirect`     | `to` (string) - relative (inside Dashboard) or absolute URL path |             |
-|                | `newContext` (boolean) - should open in a new browsing context   |             |
-| `Notification` | `status` (`info` / `success` / `warning` / `error` / undefined)  |             |
-|                | `title` (string / undefined) - title of the notification         |             |
-|                | `text` (string / undefined) - content of the notification        |             |
-|                | `apiMessage` (string / undefined) - error log from api           |             |
+| Action          | Arguments                                                        | Description                                            |
+| :-------------- | :--------------------------------------------------------------- | :----------------------------------------------------- |
+| `Redirect`      | `to` (string) - relative (inside Dashboard) or absolute URL path |                                                        |
+|                 | `newContext` (boolean) - should open in a new browsing context   |                                                        |
+| `Notification`  | `status` (`info` / `success` / `warning` / `error` / undefined)  |                                                        |
+|                 | `title` (string / undefined) - title of the notification         |                                                        |
+|                 | `text` (string / undefined) - content of the notification        |                                                        |
+|                 | `apiMessage` (string / undefined) - error log from api           |                                                        |
+| `NotifyReady`   |                                                                  | Automatically inform Dashboard that AppBridge is ready |
+| `UpdateRouting` | `newRoute` - current path of App to be set in URL                |                                                        |

--- a/src/app-bridge/actions.ts
+++ b/src/app-bridge/actions.ts
@@ -13,7 +13,7 @@ export const ActionType = {
    */
   notification: "notification",
   /**
-   * Ask Dashboard to update depp URL to preserve app route after refresh
+   * Ask Dashboard to update deep URL to preserve app route after refresh
    */
   updateRouting: "updateRouting",
   /**

--- a/src/app-bridge/actions.ts
+++ b/src/app-bridge/actions.ts
@@ -4,9 +4,22 @@ import { Values } from "./helpers";
 
 // Using constants over Enums, more info: https://fettblog.eu/tidy-typescript-avoid-enums/
 export const ActionType = {
+  /**
+   * Ask Dashboard to redirect - either internal or external route
+   */
   redirect: "redirect",
+  /**
+   * Ask Dashboard to send a notification toast
+   */
   notification: "notification",
+  /**
+   * Ask Dashboard to update depp URL to preserve app route after refresh
+   */
   updateRouting: "updateRouting",
+  /**
+   * Inform Dashboard that AppBridge is ready
+   */
+  notifyReady: "notifyReady",
 } as const;
 
 export type ActionType = Values<typeof ActionType>;
@@ -77,7 +90,6 @@ function createNotificationAction(payload: NotificationPayload): NotificationAct
 
 export type UpdateRoutingPayload = {
   newRoute: string;
-  strategy: "replace" | "push";
 };
 
 export type UpdateRouting = ActionWithId<"updateRouting", UpdateRoutingPayload>;
@@ -89,10 +101,20 @@ function createUpdateRoutingAction(payload: UpdateRoutingPayload): UpdateRouting
   });
 }
 
-export type Actions = RedirectAction | NotificationAction | UpdateRouting;
+export type NotifyReady = ActionWithId<"notifyReady", {}>;
+
+function createNotifyReadyAction(): NotifyReady {
+  return withActionId({
+    type: "notifyReady",
+    payload: {},
+  });
+}
+
+export type Actions = RedirectAction | NotificationAction | UpdateRouting | NotifyReady;
 
 export const actions = {
   Redirect: createRedirectAction,
   Notification: createNotificationAction,
   UpdateRouting: createUpdateRoutingAction,
+  NotifyReady: createNotifyReadyAction,
 };

--- a/src/app-bridge/app-bridge.test.ts
+++ b/src/app-bridge/app-bridge.test.ts
@@ -254,12 +254,12 @@ describe("AppBridge", () => {
   });
 
   it("dispatches 'notifyReady' action when created", (done) => {
-    appBridge = new AppBridge();
-
     window.addEventListener("message", (event) => {
       if (event.data.type === ActionType.notifyReady) {
         done();
       }
     });
+    
+    appBridge = new AppBridge();
   });
 });

--- a/src/app-bridge/app-bridge.ts
+++ b/src/app-bridge/app-bridge.ts
@@ -71,6 +71,11 @@ export type AppBridgeOptions = {
   targetDomain?: string;
   saleorApiUrl?: string;
   initialLocale?: LocaleCode;
+  /**
+   * Should automatically emit Actions.NotifyReady.
+   * If app loading time is longer, this can be disabled and sent manually.
+   */
+  autoNotifyReady?: boolean;
 };
 
 /**
@@ -93,6 +98,7 @@ const getDefaultOptions = (): AppBridgeOptions => ({
   targetDomain: getDomainFromUrl(),
   saleorApiUrl: getSaleorApiUrlFromUrl(),
   initialLocale: getLocaleFromUrl() ?? "en",
+  autoNotifyReady: true,
 });
 
 export class AppBridge {
@@ -145,7 +151,10 @@ export class AppBridge {
 
     this.setInitialState();
     this.listenOnMessages();
-    this.sendNotifyReadyAction();
+
+    if (this.combinedOptions.autoNotifyReady) {
+      this.sendNotifyReadyAction();
+    }
   }
 
   /**
@@ -256,6 +265,13 @@ export class AppBridge {
     return this.state.getState();
   }
 
+  sendNotifyReadyAction() {
+    this.dispatch(actions.NotifyReady()).catch((e) => {
+      console.error("notifyReady action failed");
+      console.error(e);
+    });
+  }
+
   private setInitialState() {
     debug("setInitialState() called");
 
@@ -311,12 +327,5 @@ export class AppBridge {
         }
       }
     );
-  }
-
-  private sendNotifyReadyAction() {
-    this.dispatch(actions.NotifyReady()).catch((e) => {
-      console.error("notifyReady action failed");
-      console.error(e);
-    });
   }
 }

--- a/src/app-bridge/app-bridge.ts
+++ b/src/app-bridge/app-bridge.ts
@@ -1,7 +1,7 @@
 import debugPkg from "debug";
 
 import { LocaleCode } from "../locales";
-import { Actions } from "./actions";
+import { Actions, actions } from "./actions";
 import { AppBridgeState, AppBridgeStateContainer } from "./app-bridge-state";
 import { AppIframeParams } from "./app-iframe-params";
 import { SSR } from "./constants";
@@ -145,6 +145,7 @@ export class AppBridge {
 
     this.setInitialState();
     this.listenOnMessages();
+    this.sendNotifyReadyAction();
   }
 
   /**
@@ -310,5 +311,12 @@ export class AppBridge {
         }
       }
     );
+  }
+
+  private sendNotifyReadyAction() {
+    this.dispatch(actions.NotifyReady()).catch((e) => {
+      console.error("notifyReady action failed");
+      console.error(e);
+    });
   }
 }

--- a/src/app-bridge/next/route-propagator.tsx
+++ b/src/app-bridge/next/route-propagator.tsx
@@ -24,7 +24,6 @@ export const useRoutePropagator = () => {
         ?.dispatch(
           actions.UpdateRouting({
             newRoute: url,
-            strategy: "replace",
           })
         )
         .catch(() => {


### PR DESCRIPTION
Context - when app is loaded it will be mounted in full height iframe, blinding with white/dark background (depending on app config) before theme is sent (after js loaded)

To avoid this situation, Dashboard should control when iframe is visible. Dashboard should show loading instead of iframe, and when app is loaded, show iframe

To achieve that, Dashboard must be informed when app is ready, hence new action `notifyReady` in SDK which is automatically sent when AppBridge is loaded (which means JS is loaded)