### PR TITLE
Add req and res to onError callback for AsyncWebhook

### DIFF
--- a/src/handlers/next/saleor-async-webhook.test.ts
+++ b/src/handlers/next/saleor-async-webhook.test.ts
@@ -160,14 +160,12 @@ describe("SaleorAsyncWebhook", () => {
      */
     expect(res.statusCode).toBe(401);
     expect(res._getData()).toBe("My Body");
-    /**
-     * TODO This assertion fails, due to WebhookError constructor:
-     *  [TypeError: Class constructor WebhookError cannot be invoked without 'new']
-     */
     expect(onErrorCallback).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Test error message",
-      })
+      }),
+      req,
+      res
     );
 
     /**

--- a/src/handlers/next/saleor-async-webhook.ts
+++ b/src/handlers/next/saleor-async-webhook.ts
@@ -20,7 +20,7 @@ interface WebhookManifestConfigurationBase {
   asyncEvent: AsyncWebhookEventType;
   isActive?: boolean;
   apl: APL;
-  onError?(error: WebhookError | Error): void;
+  onError?(error: WebhookError | Error, req: NextApiRequest, res: NextApiResponse): void;
   formatErrorResponse?(
     error: WebhookError | Error,
     req: NextApiRequest,
@@ -163,7 +163,7 @@ export class SaleorAsyncWebhook<TPayload = unknown> {
             debug(`Validation error: ${e.message}`);
 
             if (this.onError) {
-              this.onError(e);
+              this.onError(e, req, res);
             }
 
             if (this.formatErrorResponse) {
@@ -185,7 +185,7 @@ export class SaleorAsyncWebhook<TPayload = unknown> {
           debug("Unexpected error: %O", e);
 
           if (this.onError) {
-            this.onError(e);
+            this.onError(e, req, res);
           }
 
           if (this.formatErrorResponse) {


### PR DESCRIPTION
So this is possible now:

```
onError(error, req) {
  pino.log(req, error)
}

```