### PR TITLE
Change AppBridge default autoNotifyReady to true

### DIFF
--- a/.changeset/sharp-yaks-rush.md
+++ b/.changeset/sharp-yaks-rush.md
@@ -1,0 +1,7 @@
+---
+"@saleor/app-sdk": minor
+---
+
+Change default behaviour of autoNotifyReady option in AppBridge constructor to be "true"
+
+This behavior is required by dashboard to send token in handshake in the response

--- a/src/app-bridge/app-bridge.ts
+++ b/src/app-bridge/app-bridge.ts
@@ -118,7 +118,7 @@ const getDefaultOptions = (): AppBridgeOptions => ({
   targetDomain: getDomainFromUrl(),
   saleorApiUrl: getSaleorApiUrlFromUrl(),
   initialLocale: getLocaleFromUrl() ?? "en",
-  autoNotifyReady: false,
+  autoNotifyReady: true,
   initialTheme: getThemeFromUrl() ?? undefined,
 });
 


### PR DESCRIPTION
To be merged after
https://github.com/saleor/saleor-dashboard/pull/3216

In this PR Dashboard handles this action and this is the default behaviour - App should inform that is ready to be displayed, then dashboard should initialize handshake

