### PR TITLE
Support comma-delimited x-forwarded-proto

### DIFF
--- a/.changeset/cool-knives-punch.md
+++ b/.changeset/cool-knives-punch.md
@@ -1,0 +1,5 @@
+---
+"@saleor/app-sdk": patch
+---
+
+Support comma-delimited x-forwarded-proto

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -18,6 +18,14 @@ export const getSaleorHeaders = (headers: { [name: string]: string | string[] | 
 });
 
 export const getBaseUrl = (headers: { [name: string]: string | string[] | undefined }): string => {
-  const { host, "x-forwarded-proto": protocol = "http" } = headers;
+  const { host, "x-forwarded-proto": xForwardedProto = "http" } = headers;
+
+  const xForwardedProtos = Array.isArray(xForwardedProto)
+    ? xForwardedProto.join(",")
+    : xForwardedProto;
+  const protocols = xForwardedProtos.split(",");
+  // prefer https over other protocols
+  const protocol = protocols.find((el) => el === "https") || protocols[0];
+
   return `${protocol}://${host}`;
 };

--- a/src/middleware/with-base-url.test.ts
+++ b/src/middleware/with-base-url.test.ts
@@ -28,5 +28,35 @@ describe("middleware", () => {
       expect(mockRequest.context.baseURL).toBe("https://my-saleor-env.saleor.cloud");
       expect(mockHandlerFn).toHaveBeenCalledOnce();
     });
+
+    it("supports multiple comma-delimited values in x-forwarded-proto", async () => {
+      const mockRequest = {
+        context: {},
+        headers: {
+          host: "my-saleor-env.saleor.cloud",
+          "x-forwarded-proto": "https,http",
+        },
+      } as unknown as Request;
+
+      await withBaseURL(mockHandlerFn)(mockRequest);
+
+      expect(mockRequest.context.baseURL).toBe("https://my-saleor-env.saleor.cloud");
+      expect(mockHandlerFn).toHaveBeenCalledOnce();
+    });
+
+    it("supports multiple x-forwarded-proto headers", async () => {
+      const mockRequest = {
+        context: {},
+        headers: {
+          host: "my-saleor-env.saleor.cloud",
+          "x-forwarded-proto": ["http", "ftp,https"],
+        },
+      } as unknown as Request;
+
+      await withBaseURL(mockHandlerFn)(mockRequest);
+
+      expect(mockRequest.context.baseURL).toBe("https://my-saleor-env.saleor.cloud");
+      expect(mockHandlerFn).toHaveBeenCalledOnce();
+    });
   });
 });


### PR DESCRIPTION
Some tunnel providers send multiple comma-separated values in `x-forwarded-proto` header. For example, in the case of ngrok it's `https,http`.

This PR introduces changes to handle such values correctly.