### PR TITLE
docs: update supported Saleor versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SDK for building [Saleor Apps](https://github.com/saleor/apps).
 
-Supports Saleor version 3.20+
+Supports Saleor version 3.21+
 
 <div>
   


### PR DESCRIPTION
3.20 has been EOL since April, 2026 thus this reflects the change in the README.md in order to avoid false promises that we will ensure compatibility with 3.20