### PR TITLE
Enable apps to report their content height back to the Dashboard

### DIFF
--- a/.changeset/widget-auto-resize.md
+++ b/.changeset/widget-auto-resize.md
@@ -1,0 +1,7 @@
+---
+"@saleor/app-sdk": minor
+---
+
+Add widget auto-resize helpers for detail-page sidebar extensions.
+
+Apps mounted as `*_DETAILS_WIDGETS` can call `useWidgetAutoResize()` (or `reportWidgetHeight()`) so the Dashboard iframe follows their content height instead of staying in a fixed box. Existing apps that do not adopt the hook keep the previous default height.

--- a/.changeset/widget-auto-resize.md
+++ b/.changeset/widget-auto-resize.md
@@ -4,4 +4,4 @@
 
 Add widget auto-resize helpers for detail-page sidebar extensions.
 
-Apps mounted as `*_DETAILS_WIDGETS` can call `useWidgetAutoResize()` (or `reportWidgetHeight()`) so the Dashboard iframe follows their content height instead of staying in a fixed box. Existing apps that do not adopt the hook keep the previous default height.
+Apps mounted as `*_DETAILS_WIDGETS` can attach `useWidgetAutoResize(rootRef)` (or call `postWidgetHeight()`) so the Dashboard iframe follows a widget root element's height instead of staying in a fixed box. Existing apps that do not adopt the hook keep the previous default height.

--- a/src/app-bridge/index.ts
+++ b/src/app-bridge/index.ts
@@ -10,4 +10,6 @@ export * from "./fetch";
 export * from "./form-payload";
 export * from "./types";
 export * from "./use-dashboard-token";
+export * from "./use-widget-auto-resize";
+export * from "./widget-resize";
 export * from "./with-authorization";

--- a/src/app-bridge/use-widget-auto-resize.test.tsx
+++ b/src/app-bridge/use-widget-auto-resize.test.tsx
@@ -1,8 +1,16 @@
 import { renderHook } from "@testing-library/react";
+import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useWidgetAutoResize } from "./use-widget-auto-resize";
 import { WIDGET_RESIZE_MESSAGE } from "./widget-resize";
+
+vi.mock("./app-bridge-provider", () => ({
+  useAppBridge: () => ({
+    appBridge: undefined,
+    appBridgeState: { ready: true },
+  }),
+}));
 
 class ResizeObserverMock {
   static instances: ResizeObserverMock[] = [];
@@ -27,6 +35,12 @@ class ResizeObserverMock {
   }
 }
 
+const flushAnimationFrame = async () => {
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+};
+
 describe("useWidgetAutoResize", () => {
   let postMessageSpy: ReturnType<typeof vi.fn>;
 
@@ -40,15 +54,6 @@ describe("useWidgetAutoResize", () => {
     });
 
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
-
-    Object.defineProperty(document.documentElement, "scrollHeight", {
-      configurable: true,
-      value: 180,
-    });
-    Object.defineProperty(document.body, "scrollHeight", {
-      configurable: true,
-      value: 180,
-    });
   });
 
   afterEach(() => {
@@ -59,54 +64,104 @@ describe("useWidgetAutoResize", () => {
     vi.unstubAllGlobals();
   });
 
-  it("reports height on mount", () => {
-    // Arrange & Act
-    renderHook(() => useWidgetAutoResize());
+  it("reports the root height on mount", async () => {
+    // Arrange
+    const root = document.createElement("div");
+    root.getBoundingClientRect = () =>
+      ({
+        height: 180,
+      }) as DOMRect;
+    Object.defineProperty(root, "scrollHeight", {
+      configurable: true,
+      value: 180,
+    });
+    document.body.appendChild(root);
+
+    const rootRef = createRef<HTMLDivElement>();
+    rootRef.current = root;
+
+    // Act
+    renderHook(() => useWidgetAutoResize(rootRef));
+    await flushAnimationFrame();
 
     // Assert
     expect(postMessageSpy).toHaveBeenCalledWith({ type: WIDGET_RESIZE_MESSAGE, height: 180 }, "*");
+
+    root.remove();
   });
 
-  it("observes documentElement and the target element", () => {
+  it("observes only the widget root element", () => {
     // Arrange
-    const target = document.createElement("div");
-    document.body.appendChild(target);
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    const rootRef = createRef<HTMLDivElement>();
+    rootRef.current = root;
 
     // Act
-    renderHook(() => useWidgetAutoResize({ target }));
+    renderHook(() => useWidgetAutoResize(rootRef));
 
     // Assert
     expect(ResizeObserverMock.instances).toHaveLength(1);
-    expect(ResizeObserverMock.instances[0]?.observe).toHaveBeenCalledWith(document.documentElement);
-    expect(ResizeObserverMock.instances[0]?.observe).toHaveBeenCalledWith(target);
+    expect(ResizeObserverMock.instances[0]?.observe).toHaveBeenCalledWith(root);
+    expect(ResizeObserverMock.instances[0]?.observe).not.toHaveBeenCalledWith(
+      document.documentElement,
+    );
 
-    target.remove();
+    root.remove();
   });
 
-  it("reports height again when ResizeObserver fires", () => {
+  it("reports height again when ResizeObserver fires", async () => {
     // Arrange
-    renderHook(() => useWidgetAutoResize());
-    postMessageSpy.mockClear();
+    const root = document.createElement("div");
+    root.getBoundingClientRect = () =>
+      ({
+        height: 260,
+      }) as DOMRect;
+    Object.defineProperty(root, "scrollHeight", {
+      configurable: true,
+      value: 260,
+    });
+    document.body.appendChild(root);
 
-    Object.defineProperty(document.documentElement, "scrollHeight", {
-      configurable: true,
-      value: 260,
-    });
-    Object.defineProperty(document.body, "scrollHeight", {
-      configurable: true,
-      value: 260,
-    });
+    const rootRef = createRef<HTMLDivElement>();
+    rootRef.current = root;
+
+    renderHook(() => useWidgetAutoResize(rootRef));
+    await flushAnimationFrame();
+    postMessageSpy.mockClear();
 
     // Act
     ResizeObserverMock.instances[0]?.trigger();
+    await flushAnimationFrame();
 
     // Assert
     expect(postMessageSpy).toHaveBeenCalledWith({ type: WIDGET_RESIZE_MESSAGE, height: 260 }, "*");
+
+    root.remove();
+  });
+
+  it("does not observe when disabled", () => {
+    // Arrange
+    const root = document.createElement("div");
+    const rootRef = createRef<HTMLDivElement>();
+    rootRef.current = root;
+
+    // Act
+    renderHook(() => useWidgetAutoResize(rootRef, false));
+
+    // Assert
+    expect(ResizeObserverMock.instances).toHaveLength(0);
+    expect(postMessageSpy).not.toHaveBeenCalled();
   });
 
   it("disconnects the observer on unmount", () => {
     // Arrange
-    const { unmount } = renderHook(() => useWidgetAutoResize());
+    const root = document.createElement("div");
+    const rootRef = createRef<HTMLDivElement>();
+    rootRef.current = root;
+
+    const { unmount } = renderHook(() => useWidgetAutoResize(rootRef));
 
     // Act
     unmount();

--- a/src/app-bridge/use-widget-auto-resize.test.tsx
+++ b/src/app-bridge/use-widget-auto-resize.test.tsx
@@ -1,0 +1,117 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWidgetAutoResize } from "./use-widget-auto-resize";
+import { WIDGET_RESIZE_MESSAGE } from "./widget-resize";
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+
+  callback: ResizeObserverCallback;
+
+  observe = vi.fn();
+
+  disconnect = vi.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverMock.instances.push(this);
+  }
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+
+  static reset() {
+    ResizeObserverMock.instances = [];
+  }
+}
+
+describe("useWidgetAutoResize", () => {
+  let postMessageSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ResizeObserverMock.reset();
+    postMessageSpy = vi.fn();
+
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: { postMessage: postMessageSpy },
+    });
+
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 180,
+    });
+    Object.defineProperty(document.body, "scrollHeight", {
+      configurable: true,
+      value: 180,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: window,
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("reports height on mount", () => {
+    // Arrange & Act
+    renderHook(() => useWidgetAutoResize());
+
+    // Assert
+    expect(postMessageSpy).toHaveBeenCalledWith({ type: WIDGET_RESIZE_MESSAGE, height: 180 }, "*");
+  });
+
+  it("observes documentElement and the target element", () => {
+    // Arrange
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+
+    // Act
+    renderHook(() => useWidgetAutoResize({ target }));
+
+    // Assert
+    expect(ResizeObserverMock.instances).toHaveLength(1);
+    expect(ResizeObserverMock.instances[0]?.observe).toHaveBeenCalledWith(document.documentElement);
+    expect(ResizeObserverMock.instances[0]?.observe).toHaveBeenCalledWith(target);
+
+    target.remove();
+  });
+
+  it("reports height again when ResizeObserver fires", () => {
+    // Arrange
+    renderHook(() => useWidgetAutoResize());
+    postMessageSpy.mockClear();
+
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 260,
+    });
+    Object.defineProperty(document.body, "scrollHeight", {
+      configurable: true,
+      value: 260,
+    });
+
+    // Act
+    ResizeObserverMock.instances[0]?.trigger();
+
+    // Assert
+    expect(postMessageSpy).toHaveBeenCalledWith({ type: WIDGET_RESIZE_MESSAGE, height: 260 }, "*");
+  });
+
+  it("disconnects the observer on unmount", () => {
+    // Arrange
+    const { unmount } = renderHook(() => useWidgetAutoResize());
+
+    // Act
+    unmount();
+
+    // Assert
+    expect(ResizeObserverMock.instances[0]?.disconnect).toHaveBeenCalled();
+  });
+});

--- a/src/app-bridge/use-widget-auto-resize.ts
+++ b/src/app-bridge/use-widget-auto-resize.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+import { SSR } from "./constants";
+import { measureWidgetHeight, reportWidgetHeight } from "./widget-resize";
+
+export interface UseWidgetAutoResizeOptions {
+  /**
+   * Root element whose size drives the iframe height. Defaults to
+   * `document.body`.
+   */
+  target?: HTMLElement | null;
+}
+
+/**
+ * Automatically report widget content height to the Saleor Dashboard.
+ *
+ * Use on routes mounted as `*_DETAILS_WIDGETS` extensions so the iframe grows
+ * and shrinks with your content instead of staying in a fixed box.
+ *
+ * Opt-in and backward compatible: existing apps that omit this hook keep the
+ * Dashboard's default widget height until they adopt it.
+ *
+ * @example
+ * ```tsx
+ * export default function ProductDetailsWidgetPage() {
+ *   useWidgetAutoResize();
+ *   return <MyWidgetContent />;
+ * }
+ * ```
+ */
+export const useWidgetAutoResize = ({ target }: UseWidgetAutoResizeOptions = {}): void => {
+  useEffect(() => {
+    if (SSR) {
+      return undefined;
+    }
+
+    const getRoot = () => target ?? document.body;
+
+    const report = () => {
+      reportWidgetHeight(measureWidgetHeight(getRoot()));
+    };
+
+    report();
+
+    const resizeObserver = new ResizeObserver(report);
+
+    resizeObserver.observe(document.documentElement);
+    resizeObserver.observe(getRoot());
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [target]);
+};

--- a/src/app-bridge/use-widget-auto-resize.ts
+++ b/src/app-bridge/use-widget-auto-resize.ts
@@ -1,18 +1,12 @@
-import { useEffect } from "react";
+import { type RefObject, useEffect } from "react";
 
+import { useAppBridge } from "./app-bridge-provider";
 import { SSR } from "./constants";
-import { measureWidgetHeight, reportWidgetHeight } from "./widget-resize";
-
-export interface UseWidgetAutoResizeOptions {
-  /**
-   * Root element whose size drives the iframe height. Defaults to
-   * `document.body`.
-   */
-  target?: HTMLElement | null;
-}
+import { postWidgetHeight } from "./widget-resize";
 
 /**
- * Automatically report widget content height to the Saleor Dashboard.
+ * Size the Dashboard iframe to a widget root element — not `html`/`body`, which
+ * stretch with the iframe height and produce incorrect measurements.
  *
  * Use on routes mounted as `*_DETAILS_WIDGETS` extensions so the iframe grows
  * and shrinks with your content instead of staying in a fixed box.
@@ -23,32 +17,52 @@ export interface UseWidgetAutoResizeOptions {
  * @example
  * ```tsx
  * export default function ProductDetailsWidgetPage() {
- *   useWidgetAutoResize();
- *   return <MyWidgetContent />;
+ *   const rootRef = useRef<HTMLDivElement>(null);
+ *
+ *   useWidgetAutoResize(rootRef);
+ *
+ *   return (
+ *     <div ref={rootRef}>
+ *       <MyWidgetContent />
+ *     </div>
+ *   );
  * }
  * ```
  */
-export const useWidgetAutoResize = ({ target }: UseWidgetAutoResizeOptions = {}): void => {
+export const useWidgetAutoResize = (
+  rootRef: RefObject<HTMLElement | null>,
+  enabled = true,
+): void => {
+  const { appBridgeState } = useAppBridge();
+  const bridgeReady = Boolean(appBridgeState?.ready);
+
   useEffect(() => {
-    if (SSR) {
+    if (SSR || !enabled) {
       return undefined;
     }
 
-    const getRoot = () => target ?? document.body;
+    const root = rootRef.current;
 
-    const report = () => {
-      reportWidgetHeight(measureWidgetHeight(getRoot()));
+    if (!root) {
+      return undefined;
+    }
+
+    let raf = 0;
+
+    const schedulePost = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => postWidgetHeight(root));
     };
 
-    report();
+    schedulePost();
 
-    const resizeObserver = new ResizeObserver(report);
+    const observer = new ResizeObserver(schedulePost);
 
-    resizeObserver.observe(document.documentElement);
-    resizeObserver.observe(getRoot());
+    observer.observe(root);
 
     return () => {
-      resizeObserver.disconnect();
+      cancelAnimationFrame(raf);
+      observer.disconnect();
     };
-  }, [target]);
+  }, [enabled, bridgeReady, rootRef]);
 };

--- a/src/app-bridge/widget-resize.test.ts
+++ b/src/app-bridge/widget-resize.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { measureWidgetHeight, reportWidgetHeight, WIDGET_RESIZE_MESSAGE } from "./widget-resize";
+import {
+  measureWidgetHeight,
+  postWidgetHeight,
+  reportWidgetHeight,
+  WIDGET_RESIZE_MESSAGE,
+} from "./widget-resize";
 
 describe("widget-resize", () => {
   let postMessageSpy: ReturnType<typeof vi.fn>;
@@ -55,27 +60,55 @@ describe("widget-resize", () => {
   });
 
   describe("measureWidgetHeight", () => {
-    it("returns the largest scroll height among root candidates", () => {
+    it("returns the larger of layout box height and scroll height, rounded up", () => {
       // Arrange
       const root = document.createElement("div");
-      Object.defineProperty(document.documentElement, "scrollHeight", {
-        configurable: true,
-        value: 100,
-      });
-      Object.defineProperty(document.body, "scrollHeight", {
-        configurable: true,
-        value: 150,
-      });
+      root.getBoundingClientRect = () =>
+        ({
+          height: 120,
+        }) as DOMRect;
       Object.defineProperty(root, "scrollHeight", {
         configurable: true,
-        value: 240,
+        value: 240.2,
       });
 
       // Act
       const height = measureWidgetHeight(root);
 
       // Assert
-      expect(height).toBe(240);
+      expect(height).toBe(241);
+    });
+  });
+
+  describe("postWidgetHeight", () => {
+    it("measures the root and posts the resize message", () => {
+      // Arrange
+      const root = document.createElement("div");
+      root.getBoundingClientRect = () =>
+        ({
+          height: 180,
+        }) as DOMRect;
+      Object.defineProperty(root, "scrollHeight", {
+        configurable: true,
+        value: 180,
+      });
+
+      // Act
+      postWidgetHeight(root);
+
+      // Assert
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { type: WIDGET_RESIZE_MESSAGE, height: 180 },
+        "*",
+      );
+    });
+
+    it("does nothing when root is missing", () => {
+      // Act
+      postWidgetHeight(null);
+
+      // Assert
+      expect(postMessageSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app-bridge/widget-resize.test.ts
+++ b/src/app-bridge/widget-resize.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { measureWidgetHeight, reportWidgetHeight, WIDGET_RESIZE_MESSAGE } from "./widget-resize";
+
+describe("widget-resize", () => {
+  let postMessageSpy: ReturnType<typeof vi.fn>;
+  let parentWindow: Window;
+
+  beforeEach(() => {
+    postMessageSpy = vi.fn();
+    parentWindow = { postMessage: postMessageSpy } as unknown as Window;
+
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: parentWindow,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: window,
+    });
+  });
+
+  describe("reportWidgetHeight", () => {
+    it("posts the resize message to the parent window", () => {
+      // Arrange
+      const height = 320;
+
+      // Act
+      reportWidgetHeight(height);
+
+      // Assert
+      expect(postMessageSpy).toHaveBeenCalledWith({ type: WIDGET_RESIZE_MESSAGE, height }, "*");
+    });
+
+    it("ignores non-finite heights", () => {
+      // Act
+      reportWidgetHeight(Number.NaN);
+      reportWidgetHeight(Number.POSITIVE_INFINITY);
+
+      // Assert
+      expect(postMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it("ignores non-positive heights", () => {
+      // Act
+      reportWidgetHeight(0);
+      reportWidgetHeight(-10);
+
+      // Assert
+      expect(postMessageSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("measureWidgetHeight", () => {
+    it("returns the largest scroll height among root candidates", () => {
+      // Arrange
+      const root = document.createElement("div");
+      Object.defineProperty(document.documentElement, "scrollHeight", {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(document.body, "scrollHeight", {
+        configurable: true,
+        value: 150,
+      });
+      Object.defineProperty(root, "scrollHeight", {
+        configurable: true,
+        value: 240,
+      });
+
+      // Act
+      const height = measureWidgetHeight(root);
+
+      // Assert
+      expect(height).toBe(240);
+    });
+  });
+});

--- a/src/app-bridge/widget-resize.ts
+++ b/src/app-bridge/widget-resize.ts
@@ -16,23 +16,20 @@ export interface WidgetResizeMessage {
 const isPositiveFiniteHeight = (height: number): boolean => Number.isFinite(height) && height > 0;
 
 /**
- * Measure the content height of a widget page.
+ * Measure a widget root element's content height.
  *
- * @param root Element whose scroll height should be included. Defaults to
- * `document.body`.
+ * Prefer this over `document.body` / `document.documentElement` — in an iframe
+ * those nodes stretch with the iframe, which causes incorrect feedback loops.
  */
-export const measureWidgetHeight = (root?: HTMLElement | null): number => {
+export const measureWidgetHeight = (root: HTMLElement): number => {
   if (SSR) {
     return 0;
   }
 
-  const element = root ?? document.body;
+  const layoutHeight = root.getBoundingClientRect().height;
 
-  return Math.max(
-    document.documentElement.scrollHeight,
-    document.body.scrollHeight,
-    element.scrollHeight,
-  );
+  // scrollHeight catches overflowing children without using the document viewport.
+  return Math.ceil(Math.max(layoutHeight, root.scrollHeight));
 };
 
 /**
@@ -56,4 +53,23 @@ export const reportWidgetHeight = (height: number): void => {
   };
 
   window.parent.postMessage(message, "*");
+};
+
+/**
+ * Measure a widget root and report its height to the Dashboard.
+ *
+ * No-op when not embedded in an iframe or when the root is missing.
+ */
+export const postWidgetHeight = (root?: HTMLElement | null): void => {
+  if (SSR || !window.parent || window.parent === window || !root) {
+    return;
+  }
+
+  const height = measureWidgetHeight(root);
+
+  if (!isPositiveFiniteHeight(height)) {
+    return;
+  }
+
+  reportWidgetHeight(height);
 };

--- a/src/app-bridge/widget-resize.ts
+++ b/src/app-bridge/widget-resize.ts
@@ -1,0 +1,59 @@
+import { SSR } from "./constants";
+
+/**
+ * Message type the Dashboard listens for to resize detail-page sidebar widget
+ * iframes. Keep in sync with Saleor Dashboard's useWidgetIframeAutoHeight.
+ *
+ * @see https://docs.saleor.io/developer/extending/apps/developing-apps/app-sdk/app-bridge
+ */
+export const WIDGET_RESIZE_MESSAGE = "saleor:widget:resize";
+
+export interface WidgetResizeMessage {
+  type: typeof WIDGET_RESIZE_MESSAGE;
+  height: number;
+}
+
+const isPositiveFiniteHeight = (height: number): boolean => Number.isFinite(height) && height > 0;
+
+/**
+ * Measure the content height of a widget page.
+ *
+ * @param root Element whose scroll height should be included. Defaults to
+ * `document.body`.
+ */
+export const measureWidgetHeight = (root?: HTMLElement | null): number => {
+  if (SSR) {
+    return 0;
+  }
+
+  const element = root ?? document.body;
+
+  return Math.max(
+    document.documentElement.scrollHeight,
+    document.body.scrollHeight,
+    element.scrollHeight,
+  );
+};
+
+/**
+ * Report the widget iframe height to the Saleor Dashboard.
+ *
+ * Safe to call from non-browser contexts — it becomes a no-op during SSR.
+ * Invalid heights (non-finite or non-positive) are ignored.
+ */
+export const reportWidgetHeight = (height: number): void => {
+  if (SSR || !window.parent || window.parent === window) {
+    return;
+  }
+
+  if (!isPositiveFiniteHeight(height)) {
+    return;
+  }
+
+  const message: WidgetResizeMessage = {
+    type: WIDGET_RESIZE_MESSAGE,
+    height,
+  };
+
+  window.parent.postMessage(message, "*");
+};


### PR DESCRIPTION
This way iframes can grow and shrink with the content instead of staying in a fixed box. Especially useful for detail-page sidebar extensions that often have dynamic content and need more space than the default widget height.