### PR TITLE
chore: bump codecov to v6.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: pnpm test:ci
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@0da7aa657d958d32c117fc47e1f977e7524753c7 # v5.3.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: saleor/app-sdk


### PR DESCRIPTION
Part of ENG-1623 - updates the action to https://github.com/codecov/codecov-action/releases/tag/v6.0.1, which fixes some security issues