### PR TITLE
Add refreshEntity App Bridge action

### DIFF
--- a/.changeset/refresh-entity-action.md
+++ b/.changeset/refresh-entity-action.md
@@ -1,0 +1,7 @@
+---
+"@saleor/app-sdk": minor
+---
+
+Add `actions.RefreshEntity()` App Bridge action.
+
+Apps can dispatch `actions.RefreshEntity()` to ask the Dashboard to refresh the entity active in the current context, e.g. the currently open Order or Product. The action takes no payload. It only has an effect on Dashboard versions that handle the `refreshEntity` action type.

--- a/src/app-bridge/actions.test.ts
+++ b/src/app-bridge/actions.test.ts
@@ -111,6 +111,15 @@ describe("actions.ts", () => {
     });
   });
 
+  describe("actions.RefreshEntity", () => {
+    it("Constructs action with \"refreshEntity\" type and random actionId", () => {
+      const action = actions.RefreshEntity();
+
+      expect(action.type).toBe("refreshEntity");
+      expect(action.payload.actionId).toEqual(expect.any(String));
+    });
+  });
+
   it("Throws custom error if crypto is not available", () => {
     vi.stubGlobal("crypto", {
       ...globalThis.crypto,

--- a/src/app-bridge/actions.ts
+++ b/src/app-bridge/actions.ts
@@ -47,6 +47,11 @@ export const ActionType = {
    * Only affects `*_DETAILS_WIDGETS` extensions. Available from 3.23.7.
    */
   widgetResize: "widgetResize",
+  /**
+   * Ask Dashboard to refresh the entity active in the current context,
+   * e.g. the currently open Order or Product.
+   */
+  refreshEntity: "refreshEntity",
 } as const;
 
 export type ActionType = Values<typeof ActionType>;
@@ -208,6 +213,19 @@ function createWidgetResizeAction(payload: WidgetResizePayload): WidgetResize {
   });
 }
 
+export type RefreshEntity = ActionWithId<"refreshEntity", {}>;
+
+/**
+ * Asks the Dashboard to refresh the entity active in the current context,
+ * e.g. the currently open Order or Product.
+ */
+function createRefreshEntityAction(): RefreshEntity {
+  return withActionId({
+    type: "refreshEntity",
+    payload: {},
+  });
+}
+
 function createFormPayloadUpdateAction(payload: AllFormPayloadUpdatePayloads): FormPayloadUpdate {
   return withActionId({
     type: formPayloadUpdateActionName,
@@ -224,7 +242,8 @@ export type Actions =
   | FormPayloadUpdate
   | RequestPermissions
   | PopupClose
-  | WidgetResize;
+  | WidgetResize
+  | RefreshEntity;
 
 export const actions = {
   Redirect: createRedirectAction,
@@ -235,4 +254,5 @@ export const actions = {
   FormPayloadUpdate: createFormPayloadUpdateAction,
   PopupClose: createPopupCloseAction,
   WidgetResize: createWidgetResizeAction,
+  RefreshEntity: createRefreshEntityAction,
 };


### PR DESCRIPTION
Adds actions.RefreshEntity() so apps can ask the Dashboard to refresh the entity active in the current context, e.g. the currently open Order or Product. The action takes no payload.