### PR TITLE
Add openPopup App Bridge action and extension identifier

### DIFF
--- a/.changeset/open-popup-action.md
+++ b/.changeset/open-popup-action.md
@@ -1,0 +1,9 @@
+---
+"@saleor/app-sdk": minor
+---
+
+Add `actions.OpenPopup()` App Bridge action and an `identifier` field on manifest extensions.
+
+Apps can dispatch `actions.OpenPopup({ extensionIdentifier, params })` to ask the Dashboard to open one of the same app's POPUP extensions ("full mode"), referenced by its app-defined `identifier`. Intended to be dispatched from a WIDGET extension to open a co-located POPUP extension. The optional `params` is an arbitrary JSON-serializable payload forwarded to the opened popup. It only has an effect on Dashboard versions that handle the `openPopup` action type.
+
+Manifest extensions now accept an optional `identifier` field (unique per app), used to reference a specific extension - e.g. as the `extensionIdentifier` target of `actions.OpenPopup()`.

--- a/.changeset/open-popup-action.md
+++ b/.changeset/open-popup-action.md
@@ -2,8 +2,10 @@
 "@saleor/app-sdk": minor
 ---
 
-Add `actions.OpenPopup()` App Bridge action and an `identifier` field on manifest extensions.
+Add the `openPopup` App Bridge action, the `OpenPopupParams` codec, an `identifier` field on manifest extensions, and `appParams` on AppBridge state.
 
-Apps can dispatch `actions.OpenPopup({ extensionIdentifier, params })` to ask the Dashboard to open one of the same app's POPUP extensions ("full mode"), referenced by its app-defined `identifier`. Intended to be dispatched from a WIDGET extension to open a co-located POPUP extension. The optional `params` is an arbitrary JSON-serializable payload forwarded to the opened popup. It only has an effect on Dashboard versions that handle the `openPopup` action type.
+Apps can dispatch `actions.OpenPopup({ extensionIdentifier, params })` to ask the Dashboard to open one of the same app's POPUP extensions ("full mode"), referenced by its app-defined `identifier`. Intended to be dispatched from a WIDGET extension to open a co-located POPUP extension. The optional `params` (any JSON-serializable value) is base64-serialized into the wire payload so the Dashboard forwards it verbatim into the popup iframe URL. It only has an effect on Dashboard versions that handle the `openPopup` action type.
+
+`OpenPopupParams` is a static encoder/decoder shared by the SDK and the Dashboard: `urlKey` (`"appParams"`), `maxParamsLength` (2048), `serialize(json)` (JSON → UTF-8 → base64, throws when over the cap) and `parse(value)` (base64 → JSON). When an app opened as a POPUP loads, AppBridge reads that param from its iframe URL, decodes it and exposes it as `appBridge.getState().appParams` (`undefined` when absent or malformed).
 
 Manifest extensions now accept an optional `identifier` field (unique per app), used to reference a specific extension - e.g. as the `extensionIdentifier` target of `actions.OpenPopup()`.

--- a/.changeset/open-popup-params.md
+++ b/.changeset/open-popup-params.md
@@ -1,0 +1,9 @@
+---
+"@saleor/app-sdk": minor
+---
+
+Add `OpenPopupParams` and expose decoded popup params on AppBridge state.
+
+`OpenPopupParams` is a shared encoder/decoder for the JSON payload passed with the `openPopup` App Bridge action. It exposes `urlKey` (`"appParams"`), `serialize(json)` (JSON → UTF-8 → base64, used by the Dashboard) and `parse(value)` (base64 → JSON, used by the app).
+
+When an app opened as a POPUP loads, AppBridge now reads that param from its iframe URL, decodes it and exposes it as `appBridge.getState().appParams` (`undefined` when absent or malformed).

--- a/.changeset/open-popup-params.md
+++ b/.changeset/open-popup-params.md
@@ -1,9 +1,0 @@
----
-"@saleor/app-sdk": minor
----
-
-Add `OpenPopupParams` and expose decoded popup params on AppBridge state.
-
-`OpenPopupParams` is a shared encoder/decoder for the JSON payload passed with the `openPopup` App Bridge action. It exposes `urlKey` (`"appParams"`), `serialize(json)` (JSON → UTF-8 → base64, used by the Dashboard) and `parse(value)` (base64 → JSON, used by the app).
-
-When an app opened as a POPUP loads, AppBridge now reads that param from its iframe URL, decodes it and exposes it as `appBridge.getState().appParams` (`undefined` when absent or malformed).

--- a/src/app-bridge/actions.test.ts
+++ b/src/app-bridge/actions.test.ts
@@ -120,6 +120,38 @@ describe("actions.ts", () => {
     });
   });
 
+  describe("actions.OpenPopup", () => {
+    it("Constructs action with \"openPopup\" type, random actionId and payload", () => {
+      const params = { mode: "full", nested: { id: 1 } };
+
+      const action = actions.OpenPopup({ extensionIdentifier: "main-popup", params });
+
+      expect(action.type).toBe("openPopup");
+      expect(action.payload.actionId).toEqual(expect.any(String));
+      expect(action.payload.extensionIdentifier).toBe("main-popup");
+      expect(action.payload.params).toEqual(params);
+    });
+
+    it("Constructs action without params", () => {
+      const action = actions.OpenPopup({ extensionIdentifier: "main-popup" });
+
+      expect(action.type).toBe("openPopup");
+      expect(action.payload.extensionIdentifier).toBe("main-popup");
+      expect(action.payload.params).toBeUndefined();
+    });
+
+    it.each([
+      { extensionIdentifier: "", label: "empty" },
+      { extensionIdentifier: "   ", label: "whitespace" },
+      { extensionIdentifier: undefined as unknown as string, label: "missing" },
+      { extensionIdentifier: 123 as unknown as string, label: "non-string" },
+    ])("throws when extensionIdentifier is $label", ({ extensionIdentifier }) => {
+      expect(() => actions.OpenPopup({ extensionIdentifier })).toThrow(
+        "OpenPopup extensionIdentifier must be a non-empty string.",
+      );
+    });
+  });
+
   it("Throws custom error if crypto is not available", () => {
     vi.stubGlobal("crypto", {
       ...globalThis.crypto,

--- a/src/app-bridge/actions.test.ts
+++ b/src/app-bridge/actions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { actions, NotificationPayload, RedirectPayload } from "./actions";
+import { OpenPopupParams } from "./open-popup-params";
 
 describe("actions.ts", () => {
   afterEach(() => {
@@ -121,7 +122,7 @@ describe("actions.ts", () => {
   });
 
   describe("actions.OpenPopup", () => {
-    it("Constructs action with \"openPopup\" type, random actionId and payload", () => {
+    it("Constructs action with \"openPopup\" type, random actionId and base64 appParams", () => {
       const params = { mode: "full", nested: { id: 1 } };
 
       const action = actions.OpenPopup({ extensionIdentifier: "main-popup", params });
@@ -129,7 +130,9 @@ describe("actions.ts", () => {
       expect(action.type).toBe("openPopup");
       expect(action.payload.actionId).toEqual(expect.any(String));
       expect(action.payload.extensionIdentifier).toBe("main-popup");
-      expect(action.payload.params).toEqual(params);
+      // params are serialized here so the Dashboard forwards them verbatim
+      expect(action.payload.appParams).toBe(OpenPopupParams.serialize(params));
+      expect(OpenPopupParams.parse(action.payload.appParams!)).toEqual(params);
     });
 
     it("Constructs action without params", () => {
@@ -137,7 +140,7 @@ describe("actions.ts", () => {
 
       expect(action.type).toBe("openPopup");
       expect(action.payload.extensionIdentifier).toBe("main-popup");
-      expect(action.payload.params).toBeUndefined();
+      expect(action.payload.appParams).toBeUndefined();
     });
 
     it.each([

--- a/src/app-bridge/actions.ts
+++ b/src/app-bridge/actions.ts
@@ -52,6 +52,12 @@ export const ActionType = {
    * e.g. the currently open Order or Product.
    */
   refreshEntity: "refreshEntity",
+  /**
+   * Ask Dashboard to open one of the same app's POPUP extensions ("full mode"),
+   * referenced by its app-defined `identifier`. Intended to be dispatched from a
+   * WIDGET extension to open a co-located POPUP extension of the same app.
+   */
+  openPopup: "openPopup",
 } as const;
 
 export type ActionType = Values<typeof ActionType>;
@@ -226,6 +232,44 @@ function createRefreshEntityAction(): RefreshEntity {
   });
 }
 
+export type OpenPopupPayload = {
+  /**
+   * App-defined identifier of the target POPUP extension, unique per app.
+   */
+  extensionIdentifier: string;
+  /**
+   * Arbitrary JSON payload forwarded to the opened popup. The Dashboard
+   * serializes it into the popup iframe URL, so it must be JSON-serializable.
+   */
+  params?: unknown;
+};
+
+export type OpenPopup = ActionWithId<"openPopup", OpenPopupPayload>;
+
+const OPEN_POPUP_IDENTIFIER_ERROR = "OpenPopup extensionIdentifier must be a non-empty string.";
+
+function assertValidExtensionIdentifier(
+  extensionIdentifier: unknown,
+): asserts extensionIdentifier is string {
+  if (typeof extensionIdentifier !== "string" || extensionIdentifier.trim() === "") {
+    throw new Error(OPEN_POPUP_IDENTIFIER_ERROR);
+  }
+}
+
+/**
+ * Asks the Dashboard to open one of the same app's POPUP extensions ("full
+ * mode"), referenced by its app-defined `identifier`. Only has an effect on
+ * Dashboard versions that handle the `openPopup` action type.
+ */
+function createOpenPopupAction(payload: OpenPopupPayload): OpenPopup {
+  assertValidExtensionIdentifier(payload.extensionIdentifier);
+
+  return withActionId({
+    type: "openPopup",
+    payload,
+  });
+}
+
 function createFormPayloadUpdateAction(payload: AllFormPayloadUpdatePayloads): FormPayloadUpdate {
   return withActionId({
     type: formPayloadUpdateActionName,
@@ -243,7 +287,8 @@ export type Actions =
   | RequestPermissions
   | PopupClose
   | WidgetResize
-  | RefreshEntity;
+  | RefreshEntity
+  | OpenPopup;
 
 export const actions = {
   Redirect: createRedirectAction,
@@ -255,4 +300,5 @@ export const actions = {
   PopupClose: createPopupCloseAction,
   WidgetResize: createWidgetResizeAction,
   RefreshEntity: createRefreshEntityAction,
+  OpenPopup: createOpenPopupAction,
 };

--- a/src/app-bridge/actions.ts
+++ b/src/app-bridge/actions.ts
@@ -5,6 +5,7 @@ import {
 
 import { AppPermission } from "../types";
 import { Values } from "./helpers";
+import { OpenPopupParams } from "./open-popup-params";
 
 // Using constants over Enums, more info: https://fettblog.eu/tidy-typescript-avoid-enums/
 export const ActionType = {
@@ -238,13 +239,24 @@ export type OpenPopupPayload = {
    */
   extensionIdentifier: string;
   /**
-   * Arbitrary JSON payload forwarded to the opened popup. The Dashboard
-   * serializes it into the popup iframe URL, so it must be JSON-serializable.
+   * Arbitrary JSON payload forwarded to the opened popup. Must be
+   * JSON-serializable - it's base64-serialized here (see {@link OpenPopupParams})
+   * before it leaves the app, so the Dashboard forwards it verbatim.
    */
   params?: unknown;
 };
 
-export type OpenPopup = ActionWithId<"openPopup", OpenPopupPayload>;
+/**
+ * Wire payload of the dispatched `openPopup` action. `params` is already
+ * base64-serialized into `appParams`, so the Dashboard appends it to the popup
+ * iframe URL as-is and the receiving app decodes it back into `appBridgeState`.
+ */
+export type OpenPopupActionPayload = {
+  extensionIdentifier: string;
+  appParams?: string;
+};
+
+export type OpenPopup = ActionWithId<"openPopup", OpenPopupActionPayload>;
 
 const OPEN_POPUP_IDENTIFIER_ERROR = "OpenPopup extensionIdentifier must be a non-empty string.";
 
@@ -266,7 +278,13 @@ function createOpenPopupAction(payload: OpenPopupPayload): OpenPopup {
 
   return withActionId({
     type: "openPopup",
-    payload,
+    payload: {
+      extensionIdentifier: payload.extensionIdentifier,
+      appParams:
+        payload.params === undefined || payload.params === null
+          ? undefined
+          : OpenPopupParams.serialize(payload.params),
+    },
   });
 }
 

--- a/src/app-bridge/app-bridge-state.test.ts
+++ b/src/app-bridge/app-bridge-state.test.ts
@@ -52,4 +52,17 @@ describe("app-bridge-state.ts", () => {
       }).getState().theme,
     ).toBe("dark");
   });
+
+  it("Stores appParams passed via setState", () => {
+    const instance = new AppBridgeStateContainer();
+    const appParams = { mode: "full", productId: "prod-1" };
+
+    instance.setState({ appParams });
+
+    expect(instance.getState().appParams).toEqual(appParams);
+  });
+
+  it("Leaves appParams undefined by default", () => {
+    expect(new AppBridgeStateContainer().getState().appParams).toBeUndefined();
+  });
 });

--- a/src/app-bridge/app-bridge-state.ts
+++ b/src/app-bridge/app-bridge-state.ts
@@ -30,6 +30,12 @@ export type AppBridgeState = {
     "product-translate"?: FormPayloadProductTranslate;
     "product-edit"?: FormPayloadProductEdit;
   };
+  /**
+   * Arbitrary payload passed by the `openPopup` App Bridge action when this app
+   * was opened as a POPUP from one of its own widgets. Decoded from the iframe
+   * URL on load; `undefined` when the app wasn't opened that way.
+   */
+  appParams?: unknown;
 };
 
 type Options = {

--- a/src/app-bridge/app-bridge.test.ts
+++ b/src/app-bridge/app-bridge.test.ts
@@ -290,6 +290,19 @@ describe("AppBridge", () => {
     window.location.href = currentLocationHref;
   });
 
+  it("Decodes a raw base64 appParams URL param into state", () => {
+    // base64 of JSON.stringify({ productId: "prod-42", mode: "full" })
+    const base64 = "eyJwcm9kdWN0SWQiOiJwcm9kLTQyIiwibW9kZSI6ImZ1bGwifQ==";
+
+    const currentLocationHref = window.location.href;
+
+    window.location.href = `${origin}?domain=${domain}&id=appid&appParams=${base64}`;
+
+    expect(new AppBridge().getState().appParams).toEqual({ productId: "prod-42", mode: "full" });
+
+    window.location.href = currentLocationHref;
+  });
+
   it("Leaves appParams undefined when the URL param is missing", () => {
     const currentLocationHref = window.location.href;
 

--- a/src/app-bridge/app-bridge.test.ts
+++ b/src/app-bridge/app-bridge.test.ts
@@ -12,6 +12,7 @@ import {
   FormPayloadProductEdit,
   FormPayloadProductTranslate,
   HandshakeEvent,
+  OpenPopupParams,
   ThemeEvent,
 } from ".";
 
@@ -271,6 +272,40 @@ describe("AppBridge", () => {
     window.location.href = `${origin}?domain=${domain}&id=appid&theme=${themeToOverwrite}`;
 
     expect(new AppBridge().getState().theme).toBe(themeToOverwrite);
+
+    window.location.href = currentLocationHref;
+  });
+
+  it("Parses appParams from URL and exposes it in state", () => {
+    const value = { mode: "full", productId: "prod-1" };
+
+    const currentLocationHref = window.location.href;
+
+    window.location.href = `${origin}?domain=${domain}&id=appid&${
+      OpenPopupParams.urlKey
+    }=${OpenPopupParams.serialize(value)}`;
+
+    expect(new AppBridge().getState().appParams).toEqual(value);
+
+    window.location.href = currentLocationHref;
+  });
+
+  it("Leaves appParams undefined when the URL param is missing", () => {
+    const currentLocationHref = window.location.href;
+
+    window.location.href = `${origin}?domain=${domain}&id=appid`;
+
+    expect(new AppBridge().getState().appParams).toBeUndefined();
+
+    window.location.href = currentLocationHref;
+  });
+
+  it("Leaves appParams undefined when the URL param is malformed", () => {
+    const currentLocationHref = window.location.href;
+
+    window.location.href = `${origin}?domain=${domain}&id=appid&appParams=not-valid-#@!`;
+
+    expect(new AppBridge().getState().appParams).toBeUndefined();
 
     window.location.href = currentLocationHref;
   });

--- a/src/app-bridge/app-bridge.ts
+++ b/src/app-bridge/app-bridge.ts
@@ -8,6 +8,7 @@ import { AppBridgeState, AppBridgeStateContainer } from "./app-bridge-state";
 import { AppIframeParams } from "./app-iframe-params";
 import { SSR } from "./constants";
 import { Events, EventType, PayloadOfEvent, ThemeType } from "./events";
+import { OpenPopupParams } from "./open-popup-params";
 
 const DISPATCH_RESPONSE_TIMEOUT = 10000;
 
@@ -124,6 +125,22 @@ const getThemeFromUrl = () => {
       return value;
     default:
       return undefined;
+  }
+};
+
+const getAppParamsFromUrl = (): unknown => {
+  const value = new URL(window.location.href).searchParams.get(OpenPopupParams.urlKey);
+
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return OpenPopupParams.parse(value);
+  } catch (e) {
+    console.warn(`Failed to parse "${OpenPopupParams.urlKey}" param from iframe url`, e);
+
+    return undefined;
   }
 };
 
@@ -313,6 +330,7 @@ export class AppBridge {
       theme: this.combinedOptions.initialTheme,
       saleorApiUrl: this.combinedOptions.saleorApiUrl,
       locale: this.combinedOptions.initialLocale,
+      appParams: getAppParamsFromUrl(),
     };
 
     debug("setInitialState() will setState with %j", state);

--- a/src/app-bridge/index.ts
+++ b/src/app-bridge/index.ts
@@ -8,6 +8,7 @@ export * from "./app-iframe-params";
 export * from "./events";
 export * from "./fetch";
 export * from "./form-payload";
+export * from "./open-popup-params";
 export * from "./types";
 export * from "./use-dashboard-token";
 export * from "./use-widget-auto-resize";

--- a/src/app-bridge/open-popup-params.test.ts
+++ b/src/app-bridge/open-popup-params.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenPopupParams } from "./open-popup-params";
+
+describe("OpenPopupParams", () => {
+  it("exposes the appParams url key", () => {
+    expect(OpenPopupParams.urlKey).toBe("appParams");
+  });
+
+  it("round-trips an arbitrary nested JSON value", () => {
+    const value = { mode: "full", nested: { ids: [1, 2, 3], flag: true }, nothing: null };
+
+    expect(OpenPopupParams.parse(OpenPopupParams.serialize(value))).toEqual(value);
+  });
+
+  it("round-trips non-ASCII / unicode content", () => {
+    const value = { title: "Zażółć gęślą jaźń", emoji: "🚀✨", cjk: "你好" };
+
+    expect(OpenPopupParams.parse(OpenPopupParams.serialize(value))).toEqual(value);
+  });
+
+  it("serializes to a base64 string", () => {
+    const serialized = OpenPopupParams.serialize({ a: 1 });
+
+    // valid base64 only contains these characters
+    expect(serialized).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    expect(atob(serialized)).toBe(JSON.stringify({ a: 1 }));
+  });
+
+  it("serializes a payload at the size limit", () => {
+    // { "v": "x...x" } -> pad so the stringified JSON is exactly the max length
+    const filler = "x".repeat(OpenPopupParams.maxParamsLength - JSON.stringify({ v: "" }).length);
+
+    expect(() => OpenPopupParams.serialize({ v: filler })).not.toThrow();
+  });
+
+  it("throws when the serialized JSON exceeds the size limit", () => {
+    const value = { big: "x".repeat(OpenPopupParams.maxParamsLength) };
+
+    expect(() => OpenPopupParams.serialize(value)).toThrow(/OpenPopup params too large/);
+  });
+
+  it("throws when parsing an invalid base64 / JSON value", () => {
+    expect(() => OpenPopupParams.parse("not-valid-base64-#@!")).toThrow();
+  });
+});

--- a/src/app-bridge/open-popup-params.ts
+++ b/src/app-bridge/open-popup-params.ts
@@ -1,0 +1,66 @@
+/**
+ * Encodes/decodes the arbitrary JSON payload passed alongside the `openPopup`
+ * App Bridge action.
+ *
+ * When a WIDGET dispatches `actions.OpenPopup({ extensionIdentifier, params })`,
+ * the Dashboard serializes `params` with this class and appends it to the popup
+ * iframe URL under {@link OpenPopupParams.urlKey}. The opened app reads it back
+ * with the same class - this is why both sides share a single implementation.
+ *
+ * The payload is JSON-stringified, encoded as UTF-8 and stored as base64, so it
+ * survives the trip through the URL regardless of the characters it contains.
+ *
+ * All members are static - the class is a namespace, it's never instantiated.
+ */
+export class OpenPopupParams {
+  /**
+   * Name of the URL search param the serialized payload is stored under.
+   */
+  static urlKey = "appParams";
+
+  /**
+   * Upper bound on the serialized JSON payload length (chars). Keeps the
+   * resulting iframe `src` well under the ~8 KB browser URL ceiling, leaving
+   * room for the Dashboard context params (saleorApiUrl, theme, mount ids, ...).
+   */
+  static maxParamsLength = 2048;
+
+  /**
+   * Serializes a JSON-serializable value into a base64 string ready to be put
+   * in the popup URL. Throws if the serialized JSON exceeds
+   * {@link OpenPopupParams.maxParamsLength}.
+   */
+  static serialize(json: unknown): string {
+    const stringified = JSON.stringify(json);
+
+    if (stringified.length > OpenPopupParams.maxParamsLength) {
+      throw new Error(
+        `OpenPopup params too large: ${stringified.length} chars (max ${OpenPopupParams.maxParamsLength})`,
+      );
+    }
+
+    const bytes = new TextEncoder().encode(stringified);
+
+    let binary = "";
+
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+
+    return btoa(binary);
+  }
+
+  /**
+   * Parses a base64 string produced by {@link serialize} back into the original
+   * value. Throws if the input is not valid base64 / JSON.
+   */
+  static parse(value: string): unknown {
+    const binary = atob(value);
+
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+
+    const stringified = new TextDecoder().decode(bytes);
+
+    return JSON.parse(stringified);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,12 @@ export type SyncWebhookEventType =
 interface BaseAppExtension {
   /** Name which will be displayed in the dashboard */
   label: string;
+  /**
+   * App-defined identifier of the extension, unique per app. Used to reference a
+   * specific extension - e.g. dispatching the `openPopup` App Bridge action from
+   * a WIDGET to open a co-located POPUP extension by its identifier.
+   */
+  identifier?: string;
   /** the place where the extension will be mounted */
   mount: AppExtensionMount;
   permissions: AppPermission[];


### PR DESCRIPTION
Add `actions.OpenPopup()` so a WIDGET extension can ask the Dashboard to open one of the same app's POPUP extensions ("full mode"), referenced by its app-defined `identifier`. Mirrors the Dashboard contract from saleor/saleor-dashboard#6667.

Also add an optional `identifier` field on manifest extensions, used as the `extensionIdentifier` target of the action.

docs https://github.com/saleor/saleor-docs/pull/1800