### PR TITLE
Forward specific JWT verification failure reasons

### DIFF
--- a/src/auth/get-jose-error-reason.test.ts
+++ b/src/auth/get-jose-error-reason.test.ts
@@ -1,0 +1,45 @@
+import * as jose from "jose";
+import { describe, expect, it } from "vitest";
+
+import { getJoseErrorReason } from "./get-jose-error-reason";
+
+describe("getJoseErrorReason", () => {
+  it("Surfaces the jose error code for a generic JOSE error", () => {
+    const error = new jose.errors.JWSSignatureVerificationFailed();
+
+    const reason = getJoseErrorReason(error);
+
+    expect(reason).toContain("ERR_JWS_SIGNATURE_VERIFICATION_FAILED");
+  });
+
+  it("Surfaces the jose error code for a missing matching key", () => {
+    const error = new jose.errors.JWKSNoMatchingKey();
+
+    expect(getJoseErrorReason(error)).toContain("ERR_JWKS_NO_MATCHING_KEY");
+  });
+
+  it("Surfaces the failing claim and reason for a claim validation failure", () => {
+    const error = new jose.errors.JWTExpired(
+      "exp claim timestamp check failed",
+      {},
+      "exp",
+      "check_failed",
+    );
+
+    const reason = getJoseErrorReason(error);
+
+    expect(reason).toContain("ERR_JWT_EXPIRED");
+    expect(reason).toContain("claim=");
+    expect(reason).toContain("exp");
+    expect(reason).toContain("reason=");
+    expect(reason).toContain("check_failed");
+  });
+
+  it("Falls back to the message for a plain Error", () => {
+    expect(getJoseErrorReason(new Error("boom"))).toBe("boom");
+  });
+
+  it("Stringifies non-error values", () => {
+    expect(getJoseErrorReason("just a string")).toBe("just a string");
+  });
+});

--- a/src/auth/get-jose-error-reason.ts
+++ b/src/auth/get-jose-error-reason.ts
@@ -1,0 +1,40 @@
+import * as jose from "jose";
+
+/**
+ * Extracts a specific, human-readable reason from an error thrown while verifying
+ * a JWT / JWKS signature.
+ *
+ * jose throws typed errors that carry a machine-readable `code`
+ * (e.g. `ERR_JWKS_NO_MATCHING_KEY`, `ERR_JWS_SIGNATURE_VERIFICATION_FAILED`,
+ * `ERR_JWT_EXPIRED`) and, for claim validation failures, the offending `claim`
+ * and `reason`. We surface all of this so that otherwise opaque
+ * "verification failed" errors can actually be debugged from logs / responses.
+ */
+export const getJoseErrorReason = (error: unknown): string => {
+  if (
+    error instanceof jose.errors.JWTClaimValidationFailed ||
+    error instanceof jose.errors.JWTExpired
+  ) {
+    const parts = [`${error.code}: ${error.message}`];
+
+    if (error.claim) {
+      parts.push(`claim="${error.claim}"`);
+    }
+
+    if (error.reason) {
+      parts.push(`reason="${error.reason}"`);
+    }
+
+    return parts.join(", ");
+  }
+
+  if (error instanceof jose.errors.JOSEError) {
+    return `${error.code}: ${error.message}`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};

--- a/src/auth/verify-jwt.test.ts
+++ b/src/auth/verify-jwt.test.ts
@@ -84,4 +84,13 @@ describe("verifyJWT", () => {
       verifyJWT({ appId: validAppId, saleorApiUrl: validApiUrl, token: validToken }),
     ).rejects.toThrow("JWT verification failed: JWT signature verification failed.");
   });
+
+  it("Forwards the specific jose error code and token expiry when signature verification fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(jose.jwtVerify).mockRejectedValueOnce(new jose.errors.JWKSNoMatchingKey());
+
+    await expect(
+      verifyJWT({ appId: validAppId, saleorApiUrl: validApiUrl, token: validToken }),
+    ).rejects.toThrow(/Reason: ERR_JWKS_NO_MATCHING_KEY.*Token exp: 2022-11-24/s);
+  });
 });

--- a/src/auth/verify-jwt.ts
+++ b/src/auth/verify-jwt.ts
@@ -10,6 +10,18 @@ import { verifyTokenExpiration } from "./verify-token-expiration";
 
 const debug = createDebug("verify-jwt");
 
+/**
+ * Format a unix-seconds timestamp (as found in JWT exp/iat claims) for logging.
+ * Returns the human-readable ISO date alongside the raw value so logs are unambiguous.
+ */
+const formatJwtTimestamp = (timestampInSeconds: number | undefined) => {
+  if (typeof timestampInSeconds !== "number") {
+    return "missing";
+  }
+
+  return `${new Date(timestampInSeconds * 1000).toISOString()} (${timestampInSeconds})`;
+};
+
 export interface DashboardTokenPayload extends jose.JWTPayload {
   app: string;
   user_permissions: Permission[];
@@ -30,18 +42,6 @@ export const verifyJWT = async ({
 }: verifyJWTArguments) => {
   let tokenClaims: DashboardTokenPayload;
   const ERROR_MESSAGE = "JWT verification failed:";
-
-  /**
-   * Format a unix-seconds timestamp (as found in JWT exp/iat claims) for logging.
-   * Returns the human-readable ISO date alongside the raw value so logs are unambiguous.
-   */
-  const formatJwtTimestamp = (timestampInSeconds: number | undefined) => {
-    if (typeof timestampInSeconds !== "number") {
-      return "missing";
-    }
-
-    return `${new Date(timestampInSeconds * 1000).toISOString()} (${timestampInSeconds})`;
-  };
 
   try {
     tokenClaims = jose.decodeJwt(token as string) as DashboardTokenPayload;

--- a/src/auth/verify-jwt.ts
+++ b/src/auth/verify-jwt.ts
@@ -4,6 +4,7 @@ import { getJwksUrlFromSaleorApiUrl } from "@/auth/index";
 
 import { createDebug } from "../debug";
 import { Permission } from "../types";
+import { getJoseErrorReason } from "./get-jose-error-reason";
 import { hasPermissionsInJwtToken } from "./has-permissions-in-jwt-token";
 import { verifyTokenExpiration } from "./verify-token-expiration";
 
@@ -30,9 +31,27 @@ export const verifyJWT = async ({
   let tokenClaims: DashboardTokenPayload;
   const ERROR_MESSAGE = "JWT verification failed:";
 
+  /**
+   * Format a unix-seconds timestamp (as found in JWT exp/iat claims) for logging.
+   * Returns the human-readable ISO date alongside the raw value so logs are unambiguous.
+   */
+  const formatJwtTimestamp = (timestampInSeconds: number | undefined) => {
+    if (typeof timestampInSeconds !== "number") {
+      return "missing";
+    }
+
+    return `${new Date(timestampInSeconds * 1000).toISOString()} (${timestampInSeconds})`;
+  };
+
   try {
     tokenClaims = jose.decodeJwt(token as string) as DashboardTokenPayload;
     debug("Token Claims decoded from jwt");
+    debug(
+      "Token timing - now: %s, exp: %s, iat: %s",
+      new Date().toISOString(),
+      formatJwtTimestamp(tokenClaims.exp),
+      formatJwtTimestamp(tokenClaims.iat),
+    );
   } catch (e) {
     debug("Token Claims could not be decoded from JWT, will respond with Bad Request");
     throw new Error(`${ERROR_MESSAGE} Could not decode authorization token.`, {
@@ -68,13 +87,25 @@ export const verifyJWT = async ({
     debug("Trying to compare JWKS with token");
     await jose.jwtVerify(token, JWKS);
   } catch (e) {
+    const reason = getJoseErrorReason(e);
+
     debug("Failure: %s", e);
     debug("Will return with Bad Request");
 
     console.error(e);
 
-    throw new Error(`${ERROR_MESSAGE} JWT signature verification failed.`, {
-      cause: e,
-    });
+    /**
+     * Append the specific jose reason (e.g. ERR_JWKS_NO_MATCHING_KEY,
+     * ERR_JWS_SIGNATURE_VERIFICATION_FAILED, ERR_JWT_EXPIRED) and the token's
+     * expiry, so the actual cause of the failure can be diagnosed from the message.
+     */
+    throw new Error(
+      `${ERROR_MESSAGE} JWT signature verification failed. Reason: ${reason}. Token exp: ${formatJwtTimestamp(
+        tokenClaims.exp,
+      )}.`,
+      {
+        cause: e,
+      },
+    );
   }
 };

--- a/src/auth/verify-signature.ts
+++ b/src/auth/verify-signature.ts
@@ -1,6 +1,7 @@
 import * as jose from "jose";
 
 import { createDebug } from "../debug";
+import { getJoseErrorReason } from "./get-jose-error-reason";
 
 const debug = createDebug("verify-signature");
 
@@ -22,18 +23,27 @@ export const verifySignatureWithJwks = async (jwks: string, signature: string, r
     const parsedJWKS = JSON.parse(jwks);
 
     localJwks = jose.createLocalJWKSet(parsedJWKS) as jose.FlattenedVerifyGetKey;
-  } catch {
-    debug("Could not create local JWKSSet from given data: %s", jwks);
+  } catch (e) {
+    const reason = getJoseErrorReason(e);
 
-    throw new Error("JWKS verification failed - could not parse given JWKS");
+    debug("Could not create local JWKSSet from given data: %s, reason: %s", jwks, reason);
+
+    throw new Error(`JWKS verification failed - could not parse given JWKS. Reason: ${reason}`, {
+      cause: e,
+    });
   }
 
   try {
     await jose.flattenedVerify(jws, localJwks);
     debug("JWKS verified");
-  } catch {
-    debug("JWKS verification failed");
-    throw new Error("JWKS verification failed");
+  } catch (e) {
+    const reason = getJoseErrorReason(e);
+
+    debug("JWKS verification failed, reason: %s", reason);
+
+    throw new Error(`JWKS verification failed. Reason: ${reason}`, {
+      cause: e,
+    });
   }
 };
 

--- a/src/handlers/shared/protected-action-validator.test.ts
+++ b/src/handlers/shared/protected-action-validator.test.ts
@@ -161,6 +161,28 @@ describe("ProtectedActionValidator", () => {
       });
     });
 
+    it("should forward the specific JWT verification failure reason in the response body", async () => {
+      const validator = new ProtectedActionValidator(mockAdapter);
+
+      vi.spyOn(verifyJWTModule, "verifyJWT").mockRejectedValue(
+        new Error("JWT verification failed: Token is expired"),
+      );
+
+      const result = await validator.validateRequest({
+        apl: mockAPL,
+        requiredPermissions: ["MANAGE_APPS"],
+      });
+
+      expect(result).toEqual({
+        result: "failure",
+        value: {
+          bodyType: "string",
+          status: 401,
+          body: "Validation error: JWT verification failed: Token is expired",
+        },
+      });
+    });
+
     it("should fail validation when user extraction from JWT fails", async () => {
       const validator = new ProtectedActionValidator(mockAdapter);
 

--- a/src/handlers/shared/protected-action-validator.ts
+++ b/src/handlers/shared/protected-action-validator.ts
@@ -1,6 +1,7 @@
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 
 import { APL, AuthData } from "@/APL";
+import { getJoseErrorReason } from "@/auth/get-jose-error-reason";
 import { verifyJWT } from "@/auth/verify-jwt";
 import { createDebug } from "@/debug";
 import { getOtelTracer } from "@/open-telemetry";
@@ -151,7 +152,7 @@ export class ProtectedActionValidator<I> {
           // reason (token expired, app mismatch, missing permissions, signature
           // failure with the jose error code, etc). Forward it instead of a
           // generic message so the actual cause can be diagnosed.
-          const reason = e instanceof Error ? e.message : String(e);
+          const reason = getJoseErrorReason(e);
 
           this.debug("JWT verification failed: %s", reason);
 

--- a/src/handlers/shared/protected-action-validator.ts
+++ b/src/handlers/shared/protected-action-validator.ts
@@ -147,10 +147,22 @@ export class ProtectedActionValidator<I> {
             requiredPermissions: config.requiredPermissions,
           });
         } catch (e) {
+          // verifyJWT throws an Error whose message already carries the specific
+          // reason (token expired, app mismatch, missing permissions, signature
+          // failure with the jose error code, etc). Forward it instead of a
+          // generic message so the actual cause can be diagnosed.
+          const reason = e instanceof Error ? e.message : String(e);
+
+          this.debug("JWT verification failed: %s", reason);
+
+          if (e instanceof Error) {
+            span.recordException(e);
+          }
+
           span
             .setStatus({
               code: SpanStatusCode.ERROR,
-              message: "JWT verification failed",
+              message: reason,
             })
             .end();
 
@@ -159,7 +171,7 @@ export class ProtectedActionValidator<I> {
             value: {
               bodyType: "string",
               status: 401,
-              body: "Validation error: JWT verification failed",
+              body: `Validation error: ${reason}`,
             },
           };
         }

--- a/src/handlers/shared/saleor-webhook-validator.test.ts
+++ b/src/handlers/shared/saleor-webhook-validator.test.ts
@@ -416,7 +416,7 @@ describe("SaleorWebhookValidator", () => {
         result: "failure",
         error: {
           errorType: "SIGNATURE_VERIFICATION_FAILED",
-          message: "Fetching remote JWKS failed",
+          message: "Fetching remote JWKS failed: JWKS fetch failed",
         },
       });
       expect(fetchRemoteJwksModule.fetchRemoteJwks).toHaveBeenCalledTimes(1);
@@ -441,7 +441,8 @@ describe("SaleorWebhookValidator", () => {
         result: "failure",
         error: {
           errorType: "SIGNATURE_VERIFICATION_FAILED",
-          message: "Request signature check failed",
+          message:
+            "Request signature check failed. First attempt: Stale JWKS. Second attempt: Fresh JWKS mismatch",
         },
       });
 

--- a/src/handlers/shared/saleor-webhook-validator.ts
+++ b/src/handlers/shared/saleor-webhook-validator.ts
@@ -2,6 +2,7 @@ import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 
 import { APL } from "@/APL";
 import { fetchRemoteJwks } from "@/auth/fetch-remote-jwks";
+import { getJoseErrorReason } from "@/auth/get-jose-error-reason";
 import { createDebug } from "@/debug";
 import { getOtelTracer } from "@/open-telemetry";
 import { SaleorSchemaVersion } from "@/types";
@@ -167,10 +168,7 @@ export class SaleorWebhookValidator {
 
             await this.verifySignatureWithJwks(authData.jwks, signature, rawBody);
           } catch (firstAttemptError) {
-            const firstAttemptReason =
-              firstAttemptError instanceof Error
-                ? firstAttemptError.message
-                : String(firstAttemptError);
+            const firstAttemptReason = getJoseErrorReason(firstAttemptError);
 
             this.debug(
               "Request signature check failed (%s). Refresh the JWKS cache and check again",
@@ -181,7 +179,7 @@ export class SaleorWebhookValidator {
               this.debug("Could not fetch remote JWKS: %s", e);
 
               throw new WebhookError(
-                `Fetching remote JWKS failed: ${e instanceof Error ? e.message : String(e)}`,
+                `Fetching remote JWKS failed: ${getJoseErrorReason(e)}`,
                 "SIGNATURE_VERIFICATION_FAILED",
               );
             });
@@ -199,10 +197,7 @@ export class SaleorWebhookValidator {
 
               await apl.set({ ...authData, jwks: newJwks });
             } catch (secondAttemptError) {
-              const secondAttemptReason =
-                secondAttemptError instanceof Error
-                  ? secondAttemptError.message
-                  : String(secondAttemptError);
+              const secondAttemptReason = getJoseErrorReason(secondAttemptError);
 
               this.debug(
                 "Second attempt also ended with validation error (%s). Reject the webhook",

--- a/src/handlers/shared/saleor-webhook-validator.ts
+++ b/src/handlers/shared/saleor-webhook-validator.ts
@@ -166,14 +166,22 @@ export class SaleorWebhookValidator {
             }
 
             await this.verifySignatureWithJwks(authData.jwks, signature, rawBody);
-          } catch {
-            this.debug("Request signature check failed. Refresh the JWKS cache and check again");
+          } catch (firstAttemptError) {
+            const firstAttemptReason =
+              firstAttemptError instanceof Error
+                ? firstAttemptError.message
+                : String(firstAttemptError);
+
+            this.debug(
+              "Request signature check failed (%s). Refresh the JWKS cache and check again",
+              firstAttemptReason,
+            );
 
             const newJwks = await fetchRemoteJwks(authData.saleorApiUrl).catch((e) => {
-              this.debug(e);
+              this.debug("Could not fetch remote JWKS: %s", e);
 
               throw new WebhookError(
-                "Fetching remote JWKS failed",
+                `Fetching remote JWKS failed: ${e instanceof Error ? e.message : String(e)}`,
                 "SIGNATURE_VERIFICATION_FAILED",
               );
             });
@@ -190,11 +198,19 @@ export class SaleorWebhookValidator {
               this.debug("Verification successful - update JWKS in the AuthData");
 
               await apl.set({ ...authData, jwks: newJwks });
-            } catch {
-              this.debug("Second attempt also ended with validation error. Reject the webhook");
+            } catch (secondAttemptError) {
+              const secondAttemptReason =
+                secondAttemptError instanceof Error
+                  ? secondAttemptError.message
+                  : String(secondAttemptError);
+
+              this.debug(
+                "Second attempt also ended with validation error (%s). Reject the webhook",
+                secondAttemptReason,
+              );
 
               throw new WebhookError(
-                "Request signature check failed",
+                `Request signature check failed. First attempt: ${firstAttemptReason}. Second attempt: ${secondAttemptReason}`,
                 "SIGNATURE_VERIFICATION_FAILED",
               );
             }


### PR DESCRIPTION
JWT verification previously threw opaque "verification failed" errors and the HTTP-facing validator dropped the caught error entirely, making prod failures undebuggable.

- Add getJoseErrorReason to extract jose error codes (ERR_JWKS_NO_MATCHING_KEY, ERR_JWT_EXPIRED, etc) and claim/reason details
- verify-jwt: log token timing (now/exp/iat) and attach the specific reason plus token expiry to signature-failure errors
- protected-action-validator: forward the reason to debug logs, the OTEL span (recordException + status message) and the response body
- verify-signature / saleor-webhook-validator: attach reasons instead of swallowing errors with bare catch blocks